### PR TITLE
[codex] Fix pod leader label patching

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>jabrown93/.github//renovate-config.json"
+    "github>jabrown93/.github//renovate-config.json",
+    "customManagers:mavenPropertyVersions"
   ],
   "packageRules": [
     {

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorService.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorService.java
@@ -96,14 +96,20 @@ public class ElectorService implements SmartLifecycle {
             if (acquired) {
                 lock.set(newLock);
                 log.info("Lock '{}' acquired", electorProperties.getLockName());
-                callbacks.onLockAcquired();
+                try {
+                    callbacks.onLockAcquired();
+                } catch (final Exception e) {
+                    log.error("Lock acquired, but post-acquire callback failed; releasing lock and retrying in {}",
+                              electorProperties.getRetryPeriod(),
+                              e);
+                    releaseLockIfHeld();
+                    scheduleRetry();
+                    return;
+                }
                 scheduleRefreshTask();
             } else {
                 log.info("Could not acquire lock, will retry in {}", electorProperties.getRetryPeriod());
-                taskScheduler.schedule(this::lockLoop,
-                                       Instant
-                                               .now()
-                                               .plus(electorProperties.getRetryPeriod()));
+                scheduleRetry();
             }
         } catch (final InterruptedException e) {
             Thread
@@ -113,11 +119,17 @@ public class ElectorService implements SmartLifecycle {
         } catch (final Exception e) {
             log.error("Error while trying to acquire lock, retrying in {}", electorProperties.getRetryPeriod(), e);
             if (running.get()) {
-                taskScheduler.schedule(this::lockLoop,
-                                       Instant
-                                               .now()
-                                               .plus(electorProperties.getRetryPeriod()));
+                scheduleRetry();
             }
+        }
+    }
+
+    private void scheduleRetry() {
+        if (running.get()) {
+            taskScheduler.schedule(this::lockLoop,
+                                   Instant
+                                           .now()
+                                           .plus(electorProperties.getRetryPeriod()));
         }
     }
 

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/LockCallbacks.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/LockCallbacks.java
@@ -40,7 +40,6 @@ public class LockCallbacks {
                     .getItems();
 
             int nonLeaderUpdateFailures = 0;
-            boolean leaderUpdated = false;
 
             // Update all pods: set leader=true on self, leader=false on others
             for (final Pod pod : pods) {
@@ -48,19 +47,18 @@ public class LockCallbacks {
                         .getMetadata()
                         .getName();
                 final boolean isLeader = podName.equals(selfPodName);
-                final boolean updated = updatePodLeaderLabel(namespace, podName, isLeader);
 
                 if (isLeader) {
-                    leaderUpdated = updated;
-                } else if (!updated) {
+                    try {
+                        patchPodLeaderLabel(namespace, podName, true);
+                    } catch (final KubernetesClientException e) {
+                        final String message = "Failed to update leader label on elected pod " + selfPodName;
+                        log.error(message, e);
+                        throw new IllegalStateException(message, e);
+                    }
+                } else if (!updateNonLeaderPodLabel(namespace, podName)) {
                     nonLeaderUpdateFailures++;
                 }
-            }
-
-            if (!leaderUpdated) {
-                final String message = "Failed to update leader label on elected pod " + selfPodName;
-                log.error(message);
-                throw new IllegalStateException(message);
             }
 
             final int nonLeaderPods = pods.size() - 1;
@@ -81,23 +79,27 @@ public class LockCallbacks {
         }
     }
 
-    private boolean updatePodLeaderLabel(final String namespace, final String podName, final boolean isLeader) {
-        try {
-            final Pod patch = new PodBuilder()
-                    .withNewMetadata()
-                    .addToLabels(electorProperties.getLabelKey(), Boolean.toString(isLeader))
-                    .endMetadata()
-                    .build();
+    private void patchPodLeaderLabel(final String namespace, final String podName, final boolean isLeader) {
+        final Pod patch = new PodBuilder()
+                .withNewMetadata()
+                .addToLabels(electorProperties.getLabelKey(), Boolean.toString(isLeader))
+                .endMetadata()
+                .build();
 
-            kubernetesClient
-                    .pods()
-                    .inNamespace(namespace)
-                    .withName(podName)
-                    .patch(PatchContext.of(PatchType.JSON_MERGE), patch);
-            log.debug("Set {}={} on pod {}", electorProperties.getLabelKey(), isLeader, podName);
+        kubernetesClient
+                .pods()
+                .inNamespace(namespace)
+                .withName(podName)
+                .patch(PatchContext.of(PatchType.JSON_MERGE), patch);
+        log.debug("Set {}={} on pod {}", electorProperties.getLabelKey(), isLeader, podName);
+    }
+
+    private boolean updateNonLeaderPodLabel(final String namespace, final String podName) {
+        try {
+            patchPodLeaderLabel(namespace, podName, false);
             return true;
         } catch (final KubernetesClientException e) {
-            log.warn("Failed to update leader label on pod {}: {}", podName, e.getMessage());
+            log.warn("Failed to update leader label on pod {}", podName, e);
             return false;
         }
     }
@@ -105,6 +107,6 @@ public class LockCallbacks {
     public void onLockLost() {
         log.warn("Lock lost - removing leader label from self");
         final String namespace = kubernetesClient.getNamespace();
-        updatePodLeaderLabel(namespace, selfPodName, false);
+        updateNonLeaderPodLabel(namespace, selfPodName);
     }
 }

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/LockCallbacks.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/LockCallbacks.java
@@ -1,8 +1,11 @@
 package io.jaredbrown.k8s.leader.elector;
 
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
+import io.fabric8.kubernetes.client.dsl.base.PatchType;
 import jakarta.annotation.Nonnull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,7 +13,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
 @Component
@@ -37,18 +39,41 @@ public class LockCallbacks {
                     .list()
                     .getItems();
 
+            int nonLeaderUpdateFailures = 0;
+            boolean leaderUpdated = false;
+
             // Update all pods: set leader=true on self, leader=false on others
             for (final Pod pod : pods) {
                 final String podName = pod
                         .getMetadata()
                         .getName();
                 final boolean isLeader = podName.equals(selfPodName);
-                updatePodLeaderLabel(namespace, podName, isLeader);
+                final boolean updated = updatePodLeaderLabel(namespace, podName, isLeader);
+
+                if (isLeader) {
+                    leaderUpdated = updated;
+                } else if (!updated) {
+                    nonLeaderUpdateFailures++;
+                }
             }
 
-            log.info("Successfully updated leader labels: {} is leader, {} other pods marked as non-leader",
-                     selfPodName,
-                     pods.size() - 1);
+            if (!leaderUpdated) {
+                final String message = "Failed to update leader label on elected pod " + selfPodName;
+                log.error(message);
+                throw new IllegalStateException(message);
+            }
+
+            final int nonLeaderPods = pods.size() - 1;
+            if (nonLeaderUpdateFailures == 0) {
+                log.info("Successfully updated leader labels: {} is leader, {} other pods marked as non-leader",
+                         selfPodName,
+                         nonLeaderPods);
+            } else {
+                log.warn("Updated leader label on {}, but failed to mark {} of {} other pods as non-leader",
+                         selfPodName,
+                         nonLeaderUpdateFailures,
+                         nonLeaderPods);
+            }
         } catch (final KubernetesClientException e) {
             final String message = "Failed to update leader labels on lock acquisition";
             log.error(message, e);
@@ -56,23 +81,24 @@ public class LockCallbacks {
         }
     }
 
-    private void updatePodLeaderLabel(final String namespace, final String podName, final boolean isLeader) {
+    private boolean updatePodLeaderLabel(final String namespace, final String podName, final boolean isLeader) {
         try {
+            final Pod patch = new PodBuilder()
+                    .withNewMetadata()
+                    .addToLabels(electorProperties.getLabelKey(), Boolean.toString(isLeader))
+                    .endMetadata()
+                    .build();
+
             kubernetesClient
                     .pods()
                     .inNamespace(namespace)
                     .withName(podName)
-                    .edit(pod -> {
-                        final Map<String, String> labels = pod
-                                .getMetadata()
-                                .getLabels();
-                        labels.put(electorProperties.getLabelKey(), Boolean.toString(isLeader));
-                        return pod;
-                    });
+                    .patch(PatchContext.of(PatchType.JSON_MERGE), patch);
             log.debug("Set {}={} on pod {}", electorProperties.getLabelKey(), isLeader, podName);
+            return true;
         } catch (final KubernetesClientException e) {
             log.warn("Failed to update leader label on pod {}: {}", podName, e.getMessage());
-            // Don't throw - we want to continue updating other pods
+            return false;
         }
     }
 

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorServiceTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorServiceTest.java
@@ -122,6 +122,32 @@ class ElectorServiceTest {
     }
 
     @Test
+    void lockLoop_shouldReleaseLockAndRetryWhenLockAcquiredCallbackFails() throws Exception {
+        // Given
+        when(lockRegistry.obtain("test-lock")).thenReturn(lock);
+        when(lock.tryLock(5L, TimeUnit.SECONDS)).thenReturn(true);
+        doThrow(new IllegalStateException("failed to label elected pod"))
+                .when(callbacks)
+                .onLockAcquired();
+
+        electorService.start();
+
+        final ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler).schedule(runnableCaptor.capture(), any(Instant.class));
+
+        // When
+        runnableCaptor
+                .getValue()
+                .run();
+
+        // Then
+        verify(callbacks).onLockAcquired();
+        verify(lock).unlock();
+        verify(taskScheduler, never()).scheduleAtFixedRate(any(Runnable.class), any(Instant.class), any(Duration.class));
+        verify(taskScheduler, times(2)).schedule(any(Runnable.class), any(Instant.class));
+    }
+
+    @Test
     void lockLoop_shouldRetryWhenLockNotAcquired() throws Exception {
         // Given
         when(lockRegistry.obtain("test-lock")).thenReturn(lock);

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/LockCallbacksTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/LockCallbacksTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
@@ -108,6 +109,7 @@ class LockCallbacksTest {
                 .getMetadata()
                 .getLabels()
                 .get(LABEL_KEY));
+        assertNull(leaderPatchCaptor.getValue().getSpec());
 
         final ArgumentCaptor<Pod> followerPatchCaptor = ArgumentCaptor.forClass(Pod.class);
         verify(followerPodResource).patch(patchContextCaptor.capture(), followerPatchCaptor.capture());
@@ -165,6 +167,7 @@ class LockCallbacksTest {
         assertTrue(exception
                            .getMessage()
                            .contains("Failed to update leader label on elected pod"));
+        assertInstanceOf(KubernetesClientException.class, exception.getCause());
     }
 
     private static Pod pod(final String name) {

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/LockCallbacksTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/LockCallbacksTest.java
@@ -1,15 +1,19 @@
 package io.jaredbrown.k8s.leader.elector;
 
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
 import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.dsl.base.PatchContext;
+import io.fabric8.kubernetes.client.dsl.base.PatchType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -17,8 +21,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -71,11 +77,18 @@ class LockCallbacksTest {
     }
 
     @Test
-    void onLockAcquired_shouldQueryPodsWithCorrectLabel() {
+    void onLockAcquired_shouldPatchPodsWithJsonMergePatch() {
         // Given
+        final PodResource leaderPodResource = mock(PodResource.class);
+        final PodResource followerPodResource = mock(PodResource.class);
+        final Pod leaderPod = pod(SELF_POD_NAME);
+        final Pod followerPod = pod("pod-2");
+
         when(namespacedPods.withLabel("app", APP_NAME)).thenReturn(labeledPods);
         when(labeledPods.list()).thenReturn(podList);
-        when(podList.getItems()).thenReturn(List.of());
+        when(podList.getItems()).thenReturn(List.of(leaderPod, followerPod));
+        when(namespacedPods.withName(SELF_POD_NAME)).thenReturn(leaderPodResource);
+        when(namespacedPods.withName("pod-2")).thenReturn(followerPodResource);
 
         // When
         lockCallbacks.onLockAcquired();
@@ -83,6 +96,26 @@ class LockCallbacksTest {
         // Then
         verify(namespacedPods).withLabel("app", APP_NAME);
         verify(labeledPods).list();
+
+        final ArgumentCaptor<PatchContext> patchContextCaptor = ArgumentCaptor.forClass(PatchContext.class);
+        final ArgumentCaptor<Pod> leaderPatchCaptor = ArgumentCaptor.forClass(Pod.class);
+        verify(leaderPodResource).patch(patchContextCaptor.capture(), leaderPatchCaptor.capture());
+        assertEquals(PatchType.JSON_MERGE, patchContextCaptor
+                .getValue()
+                .getPatchType());
+        assertEquals("true", leaderPatchCaptor
+                .getValue()
+                .getMetadata()
+                .getLabels()
+                .get(LABEL_KEY));
+
+        final ArgumentCaptor<Pod> followerPatchCaptor = ArgumentCaptor.forClass(Pod.class);
+        verify(followerPodResource).patch(patchContextCaptor.capture(), followerPatchCaptor.capture());
+        assertEquals("false", followerPatchCaptor
+                .getValue()
+                .getMetadata()
+                .getLabels()
+                .get(LABEL_KEY));
     }
 
     @Test
@@ -112,5 +145,33 @@ class LockCallbacksTest {
 
         verify(kubernetesClient).getNamespace();
         verify(kubernetesClient).pods();
+    }
+
+    @Test
+    void onLockAcquired_shouldThrowWhenLeaderPodLabelUpdateFails() {
+        // Given
+        final PodResource leaderPodResource = mock(PodResource.class);
+        when(namespacedPods.withLabel("app", APP_NAME)).thenReturn(labeledPods);
+        when(labeledPods.list()).thenReturn(podList);
+        when(podList.getItems()).thenReturn(List.of(pod(SELF_POD_NAME)));
+        when(namespacedPods.withName(SELF_POD_NAME)).thenReturn(leaderPodResource);
+        when(leaderPodResource.patch(any(PatchContext.class), any(Pod.class)))
+                .thenThrow(new KubernetesClientException("immutable spec update"));
+
+        // When/Then
+        final IllegalStateException exception = assertThrows(IllegalStateException.class,
+                                                             () -> lockCallbacks.onLockAcquired());
+
+        assertTrue(exception
+                           .getMessage()
+                           .contains("Failed to update leader label on elected pod"));
+    }
+
+    private static Pod pod(final String name) {
+        return new PodBuilder()
+                .withNewMetadata()
+                .withName(name)
+                .endMetadata()
+                .build();
     }
 }

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/LockCallbacksTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/LockCallbacksTest.java
@@ -168,6 +168,7 @@ class LockCallbacksTest {
                            .getMessage()
                            .contains("Failed to update leader label on elected pod"));
         assertInstanceOf(KubernetesClientException.class, exception.getCause());
+        assertInstanceOf(KubernetesClientException.class, exception.getCause());
     }
 
     private static Pod pod(final String name) {


### PR DESCRIPTION
## Summary

Fixes pod leader label updates so the elector sends a metadata-only JSON merge patch instead of editing the full Pod object.

## Root Cause

The previous Fabric8 `edit(...)` path read and submitted the full Pod resource. When admission controllers mutated immutable `spec` fields, the resulting update could include those spec changes and Kubernetes rejected the request as an immutable pod spec update.

## Changes

- Replace Pod `edit(...)` with `patch(PatchContext.of(PatchType.JSON_MERGE), patch)` using a fresh Pod object containing only `metadata.labels`.
- Treat failure to label the elected pod as a hard failure instead of logging success.
- Keep attempting non-leader label updates and report partial failures accurately.
- Add unit coverage for JSON merge patch behavior and elected-pod label failure handling.

## Validation

- `make build`
- Surefire: 28 tests, 0 failures, 0 errors