### PR TITLE
ci: source Docker Hub creds from OpenBao-pushed Actions secrets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,15 +44,15 @@ jobs:
     - name: Login to DockerHub
       uses: docker/login-action@v4
       with:
-        username: ${{ vars.DOCKERHUB_USER }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
     - name: Login to Docker Hardened Images
       uses: docker/login-action@v4
       with:
         registry: dhi.io
-        username: ${{ vars.DOCKERHUB_USER }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
     - name: Extract tag
       id: vars

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,12 +41,6 @@ jobs:
         username: ${{ github.repository_owner }}
         password: ${{ secrets.GH_TOKEN }}
 
-    - name: Login to DockerHub
-      uses: docker/login-action@v4
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
     - name: Login to Docker Hardened Images
       uses: docker/login-action@v4
       with:


### PR DESCRIPTION
## Summary

Switches the two `docker/login-action` steps in `release.yml` (DockerHub + dhi.io) from `vars.DOCKERHUB_USER` / `secrets.DOCKERHUB_TOKEN` to `secrets.DOCKERHUB_USERNAME` / `secrets.DOCKERHUB_PASSWORD`.

Those two secrets are now written into this repo's Actions secrets by the homelab cluster's External Secrets Operator, sourced from OpenBao `default/dockerhub-credentials` — the same source and naming homelab already uses for its own dhi.io builds. This keeps the Docker Hub token out of GitHub-managed-by-hand secrets and aligns naming across repos.

## Companion / dependency
- Homelab PR jabrown93/homelab#941 adds the `gh-k8s-leader-elector` SecretStore and pushes `DOCKERHUB_USERNAME`/`DOCKERHUB_PASSWORD` here. **Merge that and let ESO populate the two secrets before merging this**, or the next release login will fail.

## After merge
- The manually-set `DOCKERHUB_TOKEN` secret and `DOCKERHUB_USER` variable in this repo become unused and can be deleted.