### PR TITLE
feat: optional health-gated leadership

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,18 @@ The application requires:
 - Lock acquisition loop with configurable retry period
 - Automatic lock renewal via scheduled executor at `renewDeadline` interval
 - Handles lock loss and attempts reacquisition automatically
+- Optional health gating (when `healthProbeEnabled`): an unhealthy pod won't acquire the lock
+  (eligibility gate in `lockLoop`), and a leader that goes unhealthy relinquishes after
+  `healthProbeFailureThreshold` consecutive failures (liveness gate in `refreshLock`). A
+  `healthProbeDeadlockGrace` escape hatch lets a degraded pod lead if no pod is healthy, so the
+  system never deadlocks leaderless (e.g. fresh install / total outage).
+
+**HealthProbe** (`src/main/java/io/jaredbrown/k8s/leader/elector/HealthProbe.java`)
+
+- Generic, tool-free fitness check: reads a status file the application maintains (typically on a
+  shared `emptyDir`). Healthy iff the file exists, is fresh (within `healthProbeMaxAge`), and its
+  trimmed content equals `healthProbeHealthyContent`. Returns `true` when probing is disabled and
+  never throws, so callers treat it as a simple boolean gate.
 
 **LockCallbacks** (`src/main/java/io/jaredbrown/k8s/leader/elector/LockCallbacks.java`)
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,46 @@
 
 Tiny Kubernetes sidecar binary that:
 
-- Acquires leadership using a `Lease` (coordination.k8s.io/v1)
+- Acquires leadership using a Redis distributed lock (Spring Integration `RedisLockRegistry`)
 - On gaining leadership, patches its own Pod with a label (default: `dns.jb.io/leader=true`)
 - On losing leadership, removes the label
+
+## Configuration
+
+Bind via environment variables (Spring relaxed binding, e.g. `elector.labelKey` →
+`ELECTOR_LABEL_KEY`).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ELECTOR_LABEL_KEY` | — | Label set to `true`/`false` to mark the leader |
+| `ELECTOR_LOCK_NAME` | — | Redis lock name |
+| `ELECTOR_SELECTOR_LABEL_KEY` / `ELECTOR_SELECTOR_LABEL_VALUE` | — | Selects the pods to label |
+| `ELECTOR_LEASE_DURATION` | `120s` | Lock lease TTL |
+| `ELECTOR_RENEW_DEADLINE` | `60s` | Lock renew interval |
+| `ELECTOR_RETRY_PERIOD` | `5s` | Acquire retry / `tryLock` wait |
+| `SPRING_DATA_REDIS_HOST` | `localhost` | Redis host backing the lock |
+| `POD_NAME` | — | This pod's name (downward API) |
+
+### Optional health-gated leadership
+
+When enabled, a pod must be **healthy** to be eligible to acquire — and to keep — leadership.
+The elector stays generic and tool-free: the application writes its own notion of "fit to lead"
+to a status file (typically on a shared `emptyDir`) and refreshes it; the elector only reads it.
+
+- **Eligibility:** an unhealthy pod will not take the lock, so a degraded pod never becomes leader.
+- **Liveness:** a leader that goes unhealthy relinquishes the lock after
+  `ELECTOR_HEALTH_PROBE_FAILURE_THRESHOLD` consecutive failures, so a healthy peer can take over.
+- **Deadlock escape hatch:** if the lock is free but *no* pod is healthy (fresh install, total
+  outage), after `ELECTOR_HEALTH_PROBE_DEADLOCK_GRACE` a pod acquires it anyway and leads in a
+  logged "degraded" state, rather than leaving the system leaderless forever.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ELECTOR_HEALTH_PROBE_ENABLED` | `false` | Master switch; off ⇒ behaves exactly as before |
+| `ELECTOR_HEALTH_PROBE_FILE_PATH` | — | Status file to read |
+| `ELECTOR_HEALTH_PROBE_HEALTHY_CONTENT` | `healthy` | Trimmed file content that means healthy |
+| `ELECTOR_HEALTH_PROBE_MAX_AGE` | `2m` | Reject the file if not updated within this window (`0` disables) |
+| `ELECTOR_HEALTH_PROBE_FAILURE_THRESHOLD` | `3` | Consecutive failures tolerated while leading |
+| `ELECTOR_HEALTH_PROBE_DEADLOCK_GRACE` | `5m` | How long to wait before leading degraded when no pod is healthy |
 
 

--- a/src/main/java/io/jaredbrown/k8s/leader/configuration/TaskSchedulerConfiguration.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/configuration/TaskSchedulerConfiguration.java
@@ -6,6 +6,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
+import java.time.Clock;
+
 @Configuration
 public class TaskSchedulerConfiguration {
     @Nonnull
@@ -17,5 +19,13 @@ public class TaskSchedulerConfiguration {
         scheduler.setDaemon(true);
         scheduler.initialize();
         return scheduler;
+    }
+
+    // System clock for time-based logic (e.g. the deadlock-grace window). Injected so tests can
+    // supply a controllable clock.
+    @Nonnull
+    @Bean
+    public Clock clock() {
+        return Clock.systemUTC();
     }
 }

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorProperties.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorProperties.java
@@ -32,4 +32,36 @@ public class ElectorProperties {
 
     @NotNull
     private Duration retryPeriod = Duration.ofSeconds(5);
+
+    // --- Optional health probe ---------------------------------------------------------------
+    // When enabled, a pod must pass a health probe to be eligible to acquire (and to keep)
+    // leadership. The probe is intentionally generic: the application writes its own notion of
+    // "fit to lead" to a status file (typically on a shared emptyDir) and the elector only reads
+    // it. This keeps application logic out of the elector and adds no tools to its image.
+    // Disabled by default so existing consumers are unaffected.
+
+    // Gate leadership on the health probe. When false, the probe is never read and behavior is
+    // identical to a probe-less elector.
+    private boolean healthProbeEnabled = false;
+
+    // Path to the status file the application maintains. Missing/unreadable file = unhealthy.
+    private String healthProbeFilePath;
+
+    // The (trimmed) file content that means healthy. Anything else = unhealthy.
+    private String healthProbeHealthyContent = "healthy";
+
+    // Reject the file if it has not been updated within this window, so a dead writer reads as
+    // unhealthy rather than stale-healthy. Set to zero to disable the freshness check.
+    @NotNull
+    private Duration healthProbeMaxAge = Duration.ofMinutes(2);
+
+    // Consecutive probe failures tolerated while already leader before relinquishing. Absorbs a
+    // transient blip or a normal gravity rebuild without flapping leadership.
+    private int healthProbeFailureThreshold = 3;
+
+    // If the lock is free but no pod is healthy, leadership would deadlock forever (e.g. a fresh
+    // install or an all-pods-wiped state). After the lock has been observed acquirable-but-this-
+    // pod-unhealthy for this long, acquire it anyway and lead in a degraded state.
+    @NotNull
+    private Duration healthProbeDeadlockGrace = Duration.ofMinutes(5);
 }

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorProperties.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorProperties.java
@@ -1,5 +1,6 @@
 package io.jaredbrown.k8s.leader.elector;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
@@ -56,7 +57,9 @@ public class ElectorProperties {
     private Duration healthProbeMaxAge = Duration.ofMinutes(2);
 
     // Consecutive probe failures tolerated while already leader before relinquishing. Absorbs a
-    // transient blip or a normal gravity rebuild without flapping leadership.
+    // transient blip or a normal gravity rebuild without flapping leadership. Must be >= 1 so a
+    // single probe failure cannot immediately demote the leader (0/negative would be nonsensical).
+    @Min(value = 1, message = "elector.healthProbeFailureThreshold must be at least 1")
     private int healthProbeFailureThreshold = 3;
 
     // If the lock is free but no pod is healthy, leadership would deadlock forever (e.g. a fresh

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorService.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorService.java
@@ -10,11 +10,13 @@ import org.springframework.integration.support.locks.DistributedLock;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 @Slf4j
@@ -29,14 +31,25 @@ public class ElectorService implements SmartLifecycle {
     private final RedisLockRegistry lockRegistry;
     @Nonnull
     private final TaskScheduler taskScheduler;
+    @Nonnull
+    private final HealthProbe healthProbe;
 
     private final AtomicReference<DistributedLock> lock = new AtomicReference<>();
     private final AtomicBoolean running = new AtomicBoolean(false);
     private final AtomicReference<ScheduledFuture<?>> refreshFuture = new AtomicReference<>();
 
+    // When the lock is free but this pod keeps failing its health probe, this records when that
+    // standoff began so the deadlock-grace escape hatch can fire. Reset whenever a leader exists
+    // (we couldn't get the lock) or we successfully lead.
+    private final AtomicReference<Instant> deadlockSince = new AtomicReference<>();
+    // Consecutive health-probe failures observed while already leading.
+    private final AtomicInteger consecutiveProbeFailures = new AtomicInteger(0);
+
     @Override
     public void start() {
         running.set(true);
+        deadlockSince.set(null);
+        consecutiveProbeFailures.set(0);
         log.info("Starting ElectorService");
         taskScheduler.schedule(this::lockLoop, Instant.now());
     }
@@ -87,27 +100,44 @@ public class ElectorService implements SmartLifecycle {
         }
 
         try {
-            log.info("Attempting to acquire lock '{}'...", electorProperties.getLockName());
+            // Probe first so the result is known whether or not the lock is free. We still attempt
+            // the lock even when unhealthy: succeeding tells us the lock is unheld, which is what
+            // the deadlock escape hatch needs to distinguish "no healthy candidate" from "a
+            // healthy leader already exists".
+            final boolean healthy = healthProbe.isHealthy();
+            log.info("Attempting to acquire lock '{}'... (healthy={})", electorProperties.getLockName(), healthy);
             final DistributedLock newLock = lockRegistry.obtain(electorProperties.getLockName());
             final boolean acquired = newLock.tryLock(electorProperties
                                                        .getRetryPeriod()
                                                        .getSeconds(), TimeUnit.SECONDS);
 
             if (acquired) {
-                lock.set(newLock);
-                log.info("Lock '{}' acquired", electorProperties.getLockName());
-                try {
-                    callbacks.onLockAcquired();
-                } catch (final Exception e) {
-                    log.error("Lock acquired, but post-acquire callback failed; releasing lock and retrying in {}",
-                              electorProperties.getRetryPeriod(),
-                              e);
-                    releaseLockIfHeld();
+                if (healthy) {
+                    deadlockSince.set(null);
+                    consecutiveProbeFailures.set(0);
+                    becomeLeader(newLock);
+                } else if (deadlockGraceExceeded()) {
+                    log.warn("Breaking leadership deadlock: acquiring lock '{}' despite a failing health probe " +
+                             "(no healthy candidate for at least {}). Leading in a DEGRADED state.",
+                             electorProperties.getLockName(),
+                             electorProperties.getHealthProbeDeadlockGrace());
+                    consecutiveProbeFailures.set(0);
+                    becomeLeader(newLock);
+                } else {
+                    // Lock is free but we're unhealthy and still within the grace window. Don't
+                    // lead yet — release so a healthy peer can take over — and retry.
+                    log.info("Lock '{}' is free but this pod fails its health probe; not eligible to lead yet, " +
+                             "releasing and retrying", electorProperties.getLockName());
+                    try {
+                        newLock.unlock();
+                    } catch (final Exception e) {
+                        log.error("Error releasing transiently held lock", e);
+                    }
                     scheduleRetry();
-                    return;
                 }
-                scheduleRefreshTask();
             } else {
+                // Someone else holds the lock: a leader exists, so we are not deadlocked.
+                deadlockSince.set(null);
                 log.info("Could not acquire lock, will retry in {}", electorProperties.getRetryPeriod());
                 scheduleRetry();
             }
@@ -122,6 +152,33 @@ public class ElectorService implements SmartLifecycle {
                 scheduleRetry();
             }
         }
+    }
+
+    private void becomeLeader(final DistributedLock newLock) {
+        lock.set(newLock);
+        log.info("Lock '{}' acquired", electorProperties.getLockName());
+        try {
+            callbacks.onLockAcquired();
+        } catch (final Exception e) {
+            log.error("Lock acquired, but post-acquire callback failed; releasing lock and retrying in {}",
+                      electorProperties.getRetryPeriod(),
+                      e);
+            releaseLockIfHeld();
+            scheduleRetry();
+            return;
+        }
+        scheduleRefreshTask();
+    }
+
+    // True once the lock has been observed free-but-this-pod-unhealthy for at least the configured
+    // grace. Starts the timer on first such observation (returning false then).
+    private boolean deadlockGraceExceeded() {
+        final Instant now = Instant.now();
+        final Instant witness = deadlockSince.compareAndExchange(null, now);
+        final Instant since = (witness == null) ? now : witness;
+        return Duration
+                       .between(since, now)
+                       .compareTo(electorProperties.getHealthProbeDeadlockGrace()) >= 0;
     }
 
     private void scheduleRetry() {
@@ -151,6 +208,29 @@ public class ElectorService implements SmartLifecycle {
             return;
         }
         try {
+            // Relinquish leadership if we go unhealthy while leading, but only after a run of
+            // failures so a transient blip (or a normal gravity rebuild) doesn't cause flapping.
+            // isHealthy() returns true when probing is disabled, so this is a no-op then.
+            if (!healthProbe.isHealthy()) {
+                final int failures = consecutiveProbeFailures.incrementAndGet();
+                final int threshold = electorProperties.getHealthProbeFailureThreshold();
+                if (failures >= threshold) {
+                    log.warn("Health probe failed {} consecutive times (threshold {}) while leading; " +
+                             "relinquishing leadership of '{}'",
+                             failures,
+                             threshold,
+                             electorProperties.getLockName());
+                    handleLockLost();
+                    return;
+                }
+                log.warn("Health probe failing while leading ({}/{}); will relinquish '{}' if it continues",
+                         failures,
+                         threshold,
+                         electorProperties.getLockName());
+            } else {
+                consecutiveProbeFailures.set(0);
+            }
+
             lockRegistry.renewLock(electorProperties.getLockName(), electorProperties.getLeaseDuration());
             log.debug("Lock TTL extended by {} seconds",
                       electorProperties
@@ -165,6 +245,7 @@ public class ElectorService implements SmartLifecycle {
     private void handleLockLost() {
         cancelRefreshTask();
         releaseLockIfHeld();
+        consecutiveProbeFailures.set(0);
 
         callbacks.onLockLost();
 

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorService.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorService.java
@@ -10,6 +10,7 @@ import org.springframework.integration.support.locks.DistributedLock;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Service;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -33,6 +34,8 @@ public class ElectorService implements SmartLifecycle {
     private final TaskScheduler taskScheduler;
     @Nonnull
     private final HealthProbe healthProbe;
+    @Nonnull
+    private final Clock clock;
 
     private final AtomicReference<DistributedLock> lock = new AtomicReference<>();
     private final AtomicBoolean running = new AtomicBoolean(false);
@@ -51,7 +54,7 @@ public class ElectorService implements SmartLifecycle {
         deadlockSince.set(null);
         consecutiveProbeFailures.set(0);
         log.info("Starting ElectorService");
-        taskScheduler.schedule(this::lockLoop, Instant.now());
+        taskScheduler.schedule(this::lockLoop, clock.instant());
     }
 
     @Override
@@ -113,15 +116,12 @@ public class ElectorService implements SmartLifecycle {
 
             if (acquired) {
                 if (healthy) {
-                    deadlockSince.set(null);
-                    consecutiveProbeFailures.set(0);
                     becomeLeader(newLock);
                 } else if (deadlockGraceExceeded()) {
                     log.warn("Breaking leadership deadlock: acquiring lock '{}' despite a failing health probe " +
                              "(no healthy candidate for at least {}). Leading in a DEGRADED state.",
                              electorProperties.getLockName(),
                              electorProperties.getHealthProbeDeadlockGrace());
-                    consecutiveProbeFailures.set(0);
                     becomeLeader(newLock);
                 } else {
                     // Lock is free but we're unhealthy and still within the grace window. Don't
@@ -155,6 +155,11 @@ public class ElectorService implements SmartLifecycle {
     }
 
     private void becomeLeader(final DistributedLock newLock) {
+        // Acquiring leadership ends any current free-lock standoff, so the deadlock-grace window
+        // must start fresh next time. Resetting here (rather than only on the healthy path) stops a
+        // degraded leader that later relinquishes from immediately re-acquiring on the stale timer.
+        deadlockSince.set(null);
+        consecutiveProbeFailures.set(0);
         lock.set(newLock);
         log.info("Lock '{}' acquired", electorProperties.getLockName());
         try {
@@ -173,7 +178,7 @@ public class ElectorService implements SmartLifecycle {
     // True once the lock has been observed free-but-this-pod-unhealthy for at least the configured
     // grace. Starts the timer on first such observation (returning false then).
     private boolean deadlockGraceExceeded() {
-        final Instant now = Instant.now();
+        final Instant now = clock.instant();
         final Instant witness = deadlockSince.compareAndExchange(null, now);
         final Instant since = (witness == null) ? now : witness;
         return Duration
@@ -184,8 +189,8 @@ public class ElectorService implements SmartLifecycle {
     private void scheduleRetry() {
         if (running.get()) {
             taskScheduler.schedule(this::lockLoop,
-                                   Instant
-                                           .now()
+                                   clock
+                                           .instant()
                                            .plus(electorProperties.getRetryPeriod()));
         }
     }
@@ -195,8 +200,8 @@ public class ElectorService implements SmartLifecycle {
     private void scheduleRefreshTask() {
         cancelRefreshTask();
         final ScheduledFuture<?> future = taskScheduler.scheduleAtFixedRate(this::refreshLock,
-                                                                            Instant
-                                                                              .now()
+                                                                            clock
+                                                                              .instant()
                                                                               .plus(electorProperties.getRenewDeadline()),
                                                                             electorProperties.getRenewDeadline());
         refreshFuture.set(future);
@@ -251,7 +256,7 @@ public class ElectorService implements SmartLifecycle {
 
         if (running.get()) {
             log.info("Scheduling re-acquire of lock after loss");
-            taskScheduler.schedule(this::lockLoop, Instant.now());
+            taskScheduler.schedule(this::lockLoop, clock.instant());
         }
     }
 

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/HealthProbe.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/HealthProbe.java
@@ -1,0 +1,83 @@
+package io.jaredbrown.k8s.leader.elector;
+
+import jakarta.annotation.Nonnull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+
+/**
+ * Decides whether this pod is fit to lead by reading a status file the application maintains.
+ *
+ * <p>The elector stays generic and tool-free: the application (e.g. on a shared {@code emptyDir})
+ * writes "healthy"/"unhealthy" to a file and keeps its modification time fresh; the elector only
+ * reads it. A missing, stale, or non-healthy file is reported as unhealthy. When the probe is
+ * disabled the pod is always considered healthy, so a probe-less elector is unchanged.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class HealthProbe {
+    @Nonnull
+    private final ElectorProperties electorProperties;
+
+    /**
+     * @return {@code true} if probing is disabled, or the status file exists, is fresh enough, and
+     * its trimmed content matches the configured healthy value. Never throws — any problem reading
+     * the file is reported as unhealthy so callers can treat it as a simple boolean gate.
+     */
+    public boolean isHealthy() {
+        if (!electorProperties.isHealthProbeEnabled()) {
+            return true;
+        }
+
+        final String filePath = electorProperties.getHealthProbeFilePath();
+        if (filePath == null || filePath.isBlank()) {
+            log.error("Health probe enabled but elector.healthProbeFilePath is not set; reporting unhealthy");
+            return false;
+        }
+
+        final Path path = Path.of(filePath);
+        try {
+            if (!Files.isReadable(path)) {
+                log.warn("Health status file {} is missing or unreadable; reporting unhealthy", filePath);
+                return false;
+            }
+
+            final Duration maxAge = electorProperties.getHealthProbeMaxAge();
+            if (maxAge != null && !maxAge.isZero() && !maxAge.isNegative()) {
+                final Instant modified = Files
+                        .getLastModifiedTime(path)
+                        .toInstant();
+                final Duration age = Duration.between(modified, Instant.now());
+                if (age.compareTo(maxAge) > 0) {
+                    log.warn("Health status file {} is stale (age {} > max {}); reporting unhealthy",
+                             filePath,
+                             age,
+                             maxAge);
+                    return false;
+                }
+            }
+
+            final String content = Files
+                    .readString(path)
+                    .trim();
+            final boolean healthy = content.equals(electorProperties.getHealthProbeHealthyContent());
+            if (!healthy) {
+                log.warn("Health status file {} content '{}' != '{}'; reporting unhealthy",
+                         filePath,
+                         content,
+                         electorProperties.getHealthProbeHealthyContent());
+            }
+            return healthy;
+        } catch (final IOException e) {
+            log.error("Failed to read health status file {}; reporting unhealthy", filePath, e);
+            return false;
+        }
+    }
+}

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorPropertiesTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorPropertiesTest.java
@@ -13,6 +13,7 @@ import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ElectorPropertiesTest {
@@ -40,6 +41,20 @@ class ElectorPropertiesTest {
         assertEquals(Duration.ofSeconds(120), properties.getLeaseDuration());
         assertEquals(Duration.ofSeconds(60), properties.getRenewDeadline());
         assertEquals(Duration.ofSeconds(5), properties.getRetryPeriod());
+    }
+
+    @Test
+    void shouldHaveHealthProbeDisabledByDefault() {
+        // When
+        final ElectorProperties properties = new ElectorProperties();
+
+        // Then — disabled with safe defaults so probe-less consumers are unaffected
+        assertFalse(properties.isHealthProbeEnabled());
+        assertNull(properties.getHealthProbeFilePath());
+        assertEquals("healthy", properties.getHealthProbeHealthyContent());
+        assertEquals(Duration.ofMinutes(2), properties.getHealthProbeMaxAge());
+        assertEquals(3, properties.getHealthProbeFailureThreshold());
+        assertEquals(Duration.ofMinutes(5), properties.getHealthProbeDeadlockGrace());
     }
 
     @Test

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorServiceTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorServiceTest.java
@@ -10,8 +10,11 @@ import org.springframework.integration.redis.util.RedisLockRegistry;
 import org.springframework.integration.support.locks.DistributedLock;
 import org.springframework.scheduling.TaskScheduler;
 
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -53,11 +56,14 @@ class ElectorServiceTest {
     @Mock
     private HealthProbe healthProbe;
 
+    private MutableClock clock;
+
     private ElectorService electorService;
 
     @BeforeEach
     void setUp() {
-        electorService = new ElectorService(callbacks, electorProperties, lockRegistry, taskScheduler, healthProbe);
+        clock = new MutableClock(Instant.parse("2026-01-01T00:00:00Z"));
+        electorService = new ElectorService(callbacks, electorProperties, lockRegistry, taskScheduler, healthProbe, clock);
 
         // Default to healthy so the existing (probe-agnostic) tests behave exactly as before; the
         // health-gate tests below override this per case.
@@ -425,6 +431,50 @@ class ElectorServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    void degradedLeader_afterRelinquishing_doesNotImmediatelyReacquireWithinGrace() throws Exception {
+        // Regression: with all pods unhealthy, the first leader breaks the deadlock once the grace
+        // elapses, then relinquishes on an unhealthy refresh. The very next acquisition attempt must
+        // start a FRESH grace window rather than re-leading on the stale timer — otherwise a single
+        // unhealthy pod monopolises leadership, re-taking it the instant it gives it up.
+        when(healthProbe.isHealthy()).thenReturn(false);
+        when(electorProperties.getHealthProbeDeadlockGrace()).thenReturn(Duration.ofMinutes(5));
+        when(electorProperties.getHealthProbeFailureThreshold()).thenReturn(1);
+        when(lockRegistry.obtain("test-lock")).thenReturn(lock);
+        when(lock.tryLock(5L, TimeUnit.SECONDS)).thenReturn(true);
+        when(taskScheduler.scheduleAtFixedRate(any(Runnable.class),
+                                               any(Instant.class),
+                                               any(Duration.class))).thenReturn((ScheduledFuture) scheduledFuture);
+
+        electorService.start();
+        final ArgumentCaptor<Runnable> loopCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler).schedule(loopCaptor.capture(), any(Instant.class));
+        final Runnable lockLoop = loopCaptor.getValue();
+
+        // 1) First loop, still within grace: starts the deadlock timer but does not lead.
+        lockLoop.run();
+        verify(callbacks, never()).onLockAcquired();
+
+        // 2) Grace elapses → next loop breaks the deadlock and leads (degraded).
+        clock.advance(Duration.ofMinutes(6));
+        lockLoop.run();
+        verify(callbacks, times(1)).onLockAcquired();
+
+        // Fire the refresh: unhealthy at threshold 1 → relinquish leadership.
+        final ArgumentCaptor<Runnable> refreshCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler).scheduleAtFixedRate(refreshCaptor.capture(), any(Instant.class), any(Duration.class));
+        refreshCaptor
+                .getValue()
+                .run();
+        verify(callbacks, times(1)).onLockLost();
+
+        // 3) Immediate re-acquire attempt, still unhealthy, no time advanced: must NOT re-lead,
+        //    proving the deadlock timer was reset on becoming leader (still only one acquisition).
+        lockLoop.run();
+        verify(callbacks, times(1)).onLockAcquired();
+    }
+
+    @Test
     void getPhase_shouldReturnIntegerMinValue() {
         // When
         final int phase = electorService.getPhase();
@@ -469,5 +519,38 @@ class ElectorServiceTest {
 
         // Then - should handle exception gracefully
         verify(lock).unlock();
+    }
+
+    // A hand-advanceable clock so deadlock-grace timing can be tested deterministically.
+    private static final class MutableClock extends Clock {
+        private Instant instant;
+
+        private MutableClock(final Instant start) {
+            this.instant = start;
+        }
+
+        private void advance(final Duration amount) {
+            this.instant = this.instant.plus(amount);
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+
+        @Override
+        public long millis() {
+            return instant.toEpochMilli();
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(final ZoneId zone) {
+            return this;
+        }
     }
 }

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorServiceTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorServiceTest.java
@@ -50,11 +50,20 @@ class ElectorServiceTest {
     @Mock
     private ScheduledFuture<?> scheduledFuture;
 
+    @Mock
+    private HealthProbe healthProbe;
+
     private ElectorService electorService;
 
     @BeforeEach
     void setUp() {
-        electorService = new ElectorService(callbacks, electorProperties, lockRegistry, taskScheduler);
+        electorService = new ElectorService(callbacks, electorProperties, lockRegistry, taskScheduler, healthProbe);
+
+        // Default to healthy so the existing (probe-agnostic) tests behave exactly as before; the
+        // health-gate tests below override this per case.
+        lenient()
+                .when(healthProbe.isHealthy())
+                .thenReturn(true);
 
         // Default property values (using lenient() for properties that may not be used in all tests)
         lenient()
@@ -296,6 +305,123 @@ class ElectorServiceTest {
 
         // Then
         assertFalse(electorService.isRunning());
+    }
+
+    @Test
+    void lockLoop_shouldNotLeadWhenUnhealthyWithinDeadlockGrace() throws Exception {
+        // Given: lock is free but this pod fails its health probe, and the grace has not elapsed
+        when(healthProbe.isHealthy()).thenReturn(false);
+        lenient()
+                .when(electorProperties.getHealthProbeDeadlockGrace())
+                .thenReturn(Duration.ofMinutes(5));
+        when(lockRegistry.obtain("test-lock")).thenReturn(lock);
+        when(lock.tryLock(5L, TimeUnit.SECONDS)).thenReturn(true);
+
+        electorService.start();
+        final ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler).schedule(runnableCaptor.capture(), any(Instant.class));
+
+        // When
+        runnableCaptor
+                .getValue()
+                .run();
+
+        // Then: it does not lead, releases the transiently-held lock, and retries
+        verify(callbacks, never()).onLockAcquired();
+        verify(lock).unlock();
+        verify(taskScheduler, never()).scheduleAtFixedRate(any(Runnable.class), any(Instant.class), any(Duration.class));
+        verify(taskScheduler, times(2)).schedule(any(Runnable.class), any(Instant.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void lockLoop_shouldBreakDeadlockAndLeadWhenUnhealthyBeyondGrace() throws Exception {
+        // Given: unhealthy, but the deadlock grace is zero so the escape hatch fires immediately
+        when(healthProbe.isHealthy()).thenReturn(false);
+        when(electorProperties.getHealthProbeDeadlockGrace()).thenReturn(Duration.ZERO);
+        when(lockRegistry.obtain("test-lock")).thenReturn(lock);
+        when(lock.tryLock(5L, TimeUnit.SECONDS)).thenReturn(true);
+        when(taskScheduler.scheduleAtFixedRate(any(Runnable.class),
+                                               any(Instant.class),
+                                               any(Duration.class))).thenReturn((ScheduledFuture) scheduledFuture);
+
+        electorService.start();
+        final ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler).schedule(runnableCaptor.capture(), any(Instant.class));
+
+        // When
+        runnableCaptor
+                .getValue()
+                .run();
+
+        // Then: it leads (degraded) rather than deadlocking forever
+        verify(callbacks).onLockAcquired();
+        verify(taskScheduler).scheduleAtFixedRate(any(Runnable.class), any(Instant.class), eq(Duration.ofSeconds(60)));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void refreshLock_shouldRelinquishAfterConsecutiveUnhealthyProbes() throws Exception {
+        // Given: healthy at acquisition, then unhealthy at the next refresh with threshold 1
+        when(healthProbe.isHealthy()).thenReturn(true, false);
+        when(electorProperties.getHealthProbeFailureThreshold()).thenReturn(1);
+        when(lockRegistry.obtain("test-lock")).thenReturn(lock);
+        when(lock.tryLock(5L, TimeUnit.SECONDS)).thenReturn(true);
+        when(taskScheduler.scheduleAtFixedRate(any(Runnable.class),
+                                               any(Instant.class),
+                                               any(Duration.class))).thenReturn((ScheduledFuture) scheduledFuture);
+
+        electorService.start();
+        final ArgumentCaptor<Runnable> lockLoopCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler).schedule(lockLoopCaptor.capture(), any(Instant.class));
+        lockLoopCaptor
+                .getValue()
+                .run();
+
+        final ArgumentCaptor<Runnable> refreshCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler).scheduleAtFixedRate(refreshCaptor.capture(), any(Instant.class), any(Duration.class));
+
+        // When
+        refreshCaptor
+                .getValue()
+                .run();
+
+        // Then: it relinquishes leadership instead of renewing
+        verify(lockRegistry, never()).renewLock(anyString(), any(Duration.class));
+        verify(callbacks).onLockLost();
+        verify(lock).unlock();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void refreshLock_shouldTolerateTransientUnhealthyBelowThreshold() throws Exception {
+        // Given: healthy at acquisition, one unhealthy refresh, threshold 3
+        when(healthProbe.isHealthy()).thenReturn(true, false);
+        when(electorProperties.getHealthProbeFailureThreshold()).thenReturn(3);
+        when(lockRegistry.obtain("test-lock")).thenReturn(lock);
+        when(lock.tryLock(5L, TimeUnit.SECONDS)).thenReturn(true);
+        when(taskScheduler.scheduleAtFixedRate(any(Runnable.class),
+                                               any(Instant.class),
+                                               any(Duration.class))).thenReturn((ScheduledFuture) scheduledFuture);
+
+        electorService.start();
+        final ArgumentCaptor<Runnable> lockLoopCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler).schedule(lockLoopCaptor.capture(), any(Instant.class));
+        lockLoopCaptor
+                .getValue()
+                .run();
+
+        final ArgumentCaptor<Runnable> refreshCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler).scheduleAtFixedRate(refreshCaptor.capture(), any(Instant.class), any(Duration.class));
+
+        // When
+        refreshCaptor
+                .getValue()
+                .run();
+
+        // Then: a single failure below the threshold keeps the lock (renews, does not relinquish)
+        verify(lockRegistry).renewLock("test-lock", Duration.ofSeconds(120));
+        verify(callbacks, never()).onLockLost();
     }
 
     @Test

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/HealthProbeTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/HealthProbeTest.java
@@ -1,0 +1,116 @@
+package io.jaredbrown.k8s.leader.elector;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class HealthProbeTest {
+
+    @Mock
+    private ElectorProperties electorProperties;
+
+    @TempDir
+    private Path tempDir;
+
+    @Test
+    void isHealthy_returnsTrueWhenProbeDisabled() {
+        when(electorProperties.isHealthProbeEnabled()).thenReturn(false);
+
+        assertTrue(new HealthProbe(electorProperties).isHealthy());
+    }
+
+    @Test
+    void isHealthy_returnsTrueWhenFileFreshAndHealthy() throws IOException {
+        final Path file = writeStatus("healthy");
+        enabled(file, Duration.ofMinutes(2));
+
+        assertTrue(new HealthProbe(electorProperties).isHealthy());
+    }
+
+    @Test
+    void isHealthy_trimsContent() throws IOException {
+        final Path file = writeStatus("  healthy\n");
+        enabled(file, Duration.ofMinutes(2));
+
+        assertTrue(new HealthProbe(electorProperties).isHealthy());
+    }
+
+    @Test
+    void isHealthy_returnsFalseWhenContentNotHealthy() throws IOException {
+        final Path file = writeStatus("unhealthy");
+        enabled(file, Duration.ofMinutes(2));
+
+        assertFalse(new HealthProbe(electorProperties).isHealthy());
+    }
+
+    @Test
+    void isHealthy_returnsFalseWhenFileMissing() {
+        enabled(tempDir.resolve("does-not-exist"), Duration.ofMinutes(2));
+
+        assertFalse(new HealthProbe(electorProperties).isHealthy());
+    }
+
+    @Test
+    void isHealthy_returnsFalseWhenFileStale() throws IOException {
+        final Path file = writeStatus("healthy");
+        Files.setLastModifiedTime(file, FileTime.from(Instant
+                                                              .now()
+                                                              .minus(Duration.ofMinutes(10))));
+        enabled(file, Duration.ofMinutes(2));
+
+        assertFalse(new HealthProbe(electorProperties).isHealthy());
+    }
+
+    @Test
+    void isHealthy_ignoresStalenessWhenMaxAgeZero() throws IOException {
+        final Path file = writeStatus("healthy");
+        Files.setLastModifiedTime(file, FileTime.from(Instant
+                                                              .now()
+                                                              .minus(Duration.ofMinutes(10))));
+        enabled(file, Duration.ZERO);
+
+        assertTrue(new HealthProbe(electorProperties).isHealthy());
+    }
+
+    @Test
+    void isHealthy_returnsFalseWhenPathUnset() {
+        when(electorProperties.isHealthProbeEnabled()).thenReturn(true);
+        lenient()
+                .when(electorProperties.getHealthProbeFilePath())
+                .thenReturn(null);
+
+        assertFalse(new HealthProbe(electorProperties).isHealthy());
+    }
+
+    private Path writeStatus(final String content) throws IOException {
+        final Path file = tempDir.resolve("status");
+        Files.writeString(file, content);
+        return file;
+    }
+
+    private void enabled(final Path file, final Duration maxAge) {
+        when(electorProperties.isHealthProbeEnabled()).thenReturn(true);
+        when(electorProperties.getHealthProbeFilePath()).thenReturn(file.toString());
+        lenient()
+                .when(electorProperties.getHealthProbeMaxAge())
+                .thenReturn(maxAge);
+        lenient()
+                .when(electorProperties.getHealthProbeHealthyContent())
+                .thenReturn("healthy");
+    }
+}


### PR DESCRIPTION
## What

Adds an **opt-in** health probe so a pod must be *fit to lead* to acquire — and to keep — leadership. Disabled by default (`healthProbeEnabled=false`), so existing consumers are unchanged and the image gains no new tooling.

## Why

A consumer (Pi-hole + nebula-sync) can have its leader silently reset to default/empty state and keep the Redis lock, then propagate the defaults. Leadership was content-blind. This lets the application express "fit to lead" and have the elector demote/skip a degraded pod.

## How — generic, tool-free

The elector never learns app specifics: the application writes `healthy`/`unhealthy` to a status file (typically a shared `emptyDir`) and keeps its mtime fresh; the elector only reads it (`HealthProbe`). No `curl`/shell added to the hardened image.

- **Eligibility gate** (`lockLoop`): an unhealthy pod won't take the lock.
- **Liveness gate** (`refreshLock`): a leader that goes unhealthy relinquishes after `healthProbeFailureThreshold` consecutive failures; a single failure below threshold rides out transient blips / a normal gravity rebuild.
- **Deadlock escape hatch**: if the lock is free but *no* pod is healthy (fresh install / total outage), after `healthProbeDeadlockGrace` a pod leads in a logged *degraded* state rather than leaving the system leaderless.

## Config (all new, all optional)

| Var | Default |
|-----|---------|
| `ELECTOR_HEALTH_PROBE_ENABLED` | `false` |
| `ELECTOR_HEALTH_PROBE_FILE_PATH` | — |
| `ELECTOR_HEALTH_PROBE_HEALTHY_CONTENT` | `healthy` |
| `ELECTOR_HEALTH_PROBE_MAX_AGE` | `2m` |
| `ELECTOR_HEALTH_PROBE_FAILURE_THRESHOLD` | `3` |
| `ELECTOR_HEALTH_PROBE_DEADLOCK_GRACE` | `5m` |

## Tests

`mvn test` — 42 pass, including new coverage for the eligibility gate, deadlock escape hatch, demote-after-threshold, transient-tolerance, and the file probe (fresh/stale/missing/content).

After merge, cut a release tag so consumers can pin the new image.