### PR TITLE
ci: use ephemeral GITHUB_TOKEN for GHCR login

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,8 @@ jobs:
       uses: docker/login-action@v4
       with:
         registry: ghcr.io
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GH_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Login to Docker Hardened Images
       uses: docker/login-action@v4


### PR DESCRIPTION
## Problem

The **v2.1.0 release** ([run 27079899323](https://github.com/jabrown93/k8s-leader-elector/actions/runs/27079899323)) failed at the **Login to GHCR** step:

\`\`\`
Logging into ghcr.io...
##[error]Error response from daemon: Get "https://ghcr.io/v2/": denied: denied
\`\`\`

The GHCR login used the static \`GH_TOKEN\` PAT, which was last rotated **2026-04-27** (the v2.0.0 release date) and has since expired / lost access. Static PATs expiring is exactly the recurring failure mode we want to eliminate.

## Fix

Use the ephemeral, auto-provisioned \`GITHUB_TOKEN\` for GHCR login instead of a static PAT. The job already declares \`permissions: packages: write\`, so no PAT is required.

\`\`\`diff
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GH_TOKEN }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
\`\`\`

## ⚠️ Possible one-time manual step

The \`ghcr.io/jabrown93/k8s-leader-elector\` package was originally published with a PAT, so it may not yet grant **this repository's** \`GITHUB_TOKEN\` write access. If the first release run after merge still reports \`denied\`:

> Package → **Settings** → **Manage Actions access** → add the \`k8s-leader-elector\` repo with **Write** role (enable "Inherit access from source repository").

This is a settings change on the package, not a code issue.

## Follow-ups (not in this PR)

- Once verified, the \`GH_TOKEN\` repo secret can be deleted (no other workflow references it).
- To recover the missed release, re-tag/re-run \`v2.1.0\` after merge.