### PR TITLE
feat(ci): Dependency-Track SBOM upload (FOSSA replacement pilot)

### DIFF
--- a/.github/workflows/dt-sbom.yml
+++ b/.github/workflows/dt-sbom.yml
@@ -1,0 +1,108 @@
+---
+# Upload a CycloneDX SBOM of this repo's resolved Maven dependencies to the
+# homelab Dependency-Track instance. This is the FOSSA replacement (fossa.yml
+# stays in place until DT is proven out across the OSS repos).
+#
+# Two jobs, because only one of them may touch the cluster:
+#   sbom   - hosted runner: resolve the full Maven dependency graph and emit
+#            target/sbom.cdx.json (cyclonedx-maven-plugin) plus project.env.
+#   upload - in-cluster arc-oss runner: exchange this run's GitHub OIDC token
+#            for the Dependency-Track CI key via OpenBao (vault-action), then
+#            POST the SBOM. arc-oss is egress-locked to a few in-cluster
+#            services, so OpenBao and DT are addressed by their in-cluster
+#            Service DNS names, not the public gateway. See
+#            github.com/jabrown93/homelab -> docs/dependency-track.md.
+#
+# push-to-main + manual only: never runs on pull_request, so fork PR code can't
+# reach the in-cluster runner. DT is visibility-only, so there is no PR gate to
+# lose by not scanning PRs.
+name: Dependency-Track SBOM
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+jobs:
+  sbom:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6.0.3
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5.2.0
+        with:
+          distribution: corretto
+          java-version: '25'
+          cache: maven
+
+      - name: Generate CycloneDX SBOM
+        run: mvn -B cyclonedx:makeAggregateBom
+
+      - name: Write project metadata
+        run: |
+          set -euo pipefail
+          {
+            echo "PROJECT_NAME=github.com/${{ github.repository }}"
+            echo "PROJECT_VERSION=${{ github.sha }}"
+          } > project.env
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v7.0.1
+        with:
+          name: sbom
+          if-no-files-found: error
+          path: |
+            target/sbom.cdx.json
+            project.env
+
+  upload:
+    needs: sbom
+    runs-on: arc-oss
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download SBOM artifact
+        uses: actions/download-artifact@v8.0.1
+        with:
+          name: sbom
+
+      - name: Load project metadata
+        id: meta
+        run: |
+          set -euo pipefail
+          set -a
+          . ./project.env
+          set +a
+          echo "name=${PROJECT_NAME}" >> "$GITHUB_OUTPUT"
+          echo "version=${PROJECT_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Fetch DT API key from OpenBao
+        id: bao
+        uses: hashicorp/vault-action@v4.0.0
+        with:
+          url: https://openbao-active.openbao.svc.cluster.local:8200
+          tlsSkipVerify: true
+          method: jwt
+          path: github-actions
+          role: dt-sbom-upload
+          jwtGithubAudience: openbao
+          secrets: |
+            secret/data/dependency-track/ci-api-key apiKey | DT_API_KEY
+
+      - name: Upload SBOM to Dependency-Track
+        env:
+          DT_API_KEY: ${{ steps.bao.outputs.DT_API_KEY }}
+        run: |
+          set -euo pipefail
+          curl -fsS -X POST http://dependency-track-api-server.dependency-track.svc.cluster.local:8080/api/v1/bom \
+            -H "X-Api-Key: ${DT_API_KEY}" \
+            -F "autoCreate=true" \
+            -F "projectName=${{ steps.meta.outputs.name }}" \
+            -F "projectVersion=${{ steps.meta.outputs.version }}" \
+            -F "isLatest=true" \
+            -F "bom=@target/sbom.cdx.json"

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <main.class>io.jaredbrown.k8s.leader.Application</main.class>
         <lombok.version>1.18.46</lombok.version>
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
+        <cyclonedx-maven-plugin.version>2.9.1</cyclonedx-maven-plugin.version>
         <spring-cloud-dependencies.version>2025.1.1</spring-cloud-dependencies.version>
         <log4j-bom.version>2.26.0</log4j-bom.version>
     </properties>
@@ -120,6 +121,20 @@
                             <artifactId>lombok</artifactId>
                         </path>
                     </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <!-- CycloneDX SBOM generation. No <executions>, so it does not bind
+                 to the build lifecycle (CI `mvn verify` and the release build are
+                 unaffected); the dt-sbom workflow invokes it explicitly via
+                 `mvn cyclonedx:makeAggregateBom`, producing target/sbom.cdx.json. -->
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>${cyclonedx-maven-plugin.version}</version>
+                <configuration>
+                    <projectType>application</projectType>
+                    <outputFormat>json</outputFormat>
+                    <outputName>sbom.cdx</outputName>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
## What

Pilot replacement for the FOSSA license scan: generate a CycloneDX SBOM of this repo's resolved Maven dependencies and upload it to the homelab **Dependency-Track** instance. This is the first repo in the FOSSA→DT migration (homelab [#1017](https://github.com/jabrown93/homelab/pull/1017) shipped the hardened `arc-oss` in-cluster runner + OpenBao role that make this possible).

`fossa.yml` is left **in place** — DT runs in parallel until it's proven across all the OSS repos, then FOSSA is removed.

## How

Two jobs, because only one may touch the cluster:

- **`sbom`** (hosted `ubuntu-latest`): `mvn cyclonedx:makeAggregateBom` resolves the full Maven dependency graph → `target/sbom.cdx.json`, plus a `project.env` carrying the DT project coordinates. Uploaded as an artifact.
- **`upload`** (in-cluster `arc-oss`): exchanges the run's GitHub OIDC token for the DT CI key via OpenBao (`hashicorp/vault-action`, JWT role `dt-sbom-upload`), then `POST`s the SBOM. `arc-oss` is egress-locked, so OpenBao and DT are addressed by their **in-cluster Service DNS** (`openbao-active.openbao.svc…:8200` with `tlsSkipVerify`, `dependency-track-api-server.dependency-track.svc…:8080`), not the public gateway.

`pom.xml` gains `cyclonedx-maven-plugin` with **no `<executions>`**, so it does not bind to the build lifecycle — `mvn verify` (CI) and the release build are unaffected; the goal only runs when invoked explicitly.

Triggers: **push to `main` + `workflow_dispatch`** only. Never `pull_request`, so fork PR code can't reach the in-cluster runner; DT is visibility-only, so there's no PR gate lost.

## Validation

- `mvn -B cyclonedx:makeAggregateBom` run locally (JDK 25 / Maven 3.9.16): produces a valid **CycloneDX 1.6** SBOM, **153 components**, at `target/sbom.cdx.json`.
- `pom.xml` XML well-formed (`xmllint`); workflow YAML parses.

## Gating before first green run

The `arc-oss` runner set is live in-cluster (`min 0 / max 2`), but the backing ARC GitHub App must grant access to this repo before it picks up the `upload` job: **GitHub → Settings → Applications → Installed GitHub Apps → [ARC app] → Repository access** → include `k8s-leader-elector`. Until then the `upload` job queues with no runner.

Once green, confirm the project appears in DT (`github.com/jabrown93/k8s-leader-elector`), then I'll fan out to the four `homebridge-*` repos (npm → `cyclonedx-npm`) and decommission FOSSA.