### PR TITLE
fix(ci): target repo-scoped runner arc-oss-k8s-leader-elector

### DIFF
--- a/.github/workflows/dt-sbom.yml
+++ b/.github/workflows/dt-sbom.yml
@@ -6,11 +6,13 @@
 # Two jobs, because only one of them may touch the cluster:
 #   sbom   - hosted runner: resolve the full Maven dependency graph and emit
 #            target/sbom.cdx.json (cyclonedx-maven-plugin) plus project.env.
-#   upload - in-cluster arc-oss runner: exchange this run's GitHub OIDC token
-#            for the Dependency-Track CI key via OpenBao (vault-action), then
-#            POST the SBOM. arc-oss is egress-locked to a few in-cluster
-#            services, so OpenBao and DT are addressed by their in-cluster
-#            Service DNS names, not the public gateway. See
+#   upload - in-cluster arc-oss-k8s-leader-elector runner: exchange this run's
+#            GitHub OIDC token for the Dependency-Track CI key via OpenBao
+#            (vault-action), then POST the SBOM. The runner is egress-locked to a
+#            few in-cluster services, so OpenBao and DT are addressed by their
+#            in-cluster Service DNS names, not the public gateway. The set is
+#            REPO-scoped (one arc-oss-<repo> set per OSS repo; a user account
+#            can't host shared runners). See
 #            github.com/jabrown93/homelab -> docs/dependency-track.md.
 #
 # push-to-main + manual only: never runs on pull_request, so fork PR code can't
@@ -61,7 +63,7 @@ jobs:
 
   upload:
     needs: sbom
-    runs-on: arc-oss
+    runs-on: arc-oss-k8s-leader-elector
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Why

The `dt-sbom.yml` `upload` job (`runs-on: arc-oss`) hangs at *"Waiting for a runner to pick up this job…"*. The `arc-oss` runner scale set can **never register**: GitHub self-hosted runners only support repository/org/enterprise scope, and `arc-oss` was pointed at the bare **user account** `https://github.com/jabrown93`. ARC calls `POST /orgs/jabrown93/.../registration-token` → `404 Not Found` (jabrown93 is a User, not an org), so the set stays `Pending` with no listener and no runner is ever offered.

## Fix

The homelab repo replaces the broken account-scoped set with per-repo, **repo-scoped** sets named `arc-oss-<repo>`. The `gha-runner-scale-set` chart couples the `runs-on` label to the scale-set name, so this repo's upload job must target **`arc-oss-k8s-leader-elector`**. Also refreshes the header comment.

No other change — OpenBao OIDC (`dt-sbom-upload` role, audience `openbao`) and the in-cluster Service URLs are unaffected.

## Ordering

Pairs with **jabrown93/homelab#1025**, which stands up the `arc-oss-k8s-leader-elector` set. Merge that first (and let it sync) so the runner exists before this lands; otherwise this job will still wait. After both merge, re-run via `workflow_dispatch` to confirm the SBOM reaches Dependency-Track.