### PR TITLE
fix(ci): harden dt-sbom upload job — drop sourced project.env

### DIFF
--- a/.github/workflows/dt-sbom.yml
+++ b/.github/workflows/dt-sbom.yml
@@ -4,15 +4,19 @@
 # stays in place until DT is proven out across the OSS repos).
 #
 # Two jobs, because only one of them may touch the cluster:
-#   sbom   - hosted runner: resolve the full Maven dependency graph and emit
-#            target/sbom.cdx.json (cyclonedx-maven-plugin) plus project.env.
+#   sbom   - hosted runner (UNTRUSTED): resolve the full Maven dependency graph
+#            and emit target/sbom.cdx.json (cyclonedx-maven-plugin). Build
+#            plugins run here, never on the in-cluster runner.
 #   upload - in-cluster arc-oss-k8s-leader-elector runner: exchange this run's
 #            GitHub OIDC token for the Dependency-Track CI key via OpenBao
-#            (vault-action), then POST the SBOM. The runner is egress-locked to a
-#            few in-cluster services, so OpenBao and DT are addressed by their
-#            in-cluster Service DNS names, not the public gateway. The set is
-#            REPO-scoped (one arc-oss-<repo> set per OSS repo; a user account
-#            can't host shared runners). See
+#            (vault-action), then POST the SBOM. Project identity is taken from
+#            trusted GitHub context (github.repository / github.sha), NOT from
+#            anything the sbom job produced, so a compromised build can't inject
+#            values that get executed on the cluster runner. The runner is
+#            egress-locked to a few in-cluster services, so OpenBao and DT are
+#            addressed by their in-cluster Service DNS names, not the public
+#            gateway. The set is REPO-scoped (one arc-oss-<repo> set per OSS repo;
+#            a user account can't host shared runners). See
 #            github.com/jabrown93/homelab -> docs/dependency-track.md.
 #
 # push-to-main + manual only: never runs on pull_request, so fork PR code can't
@@ -44,22 +48,12 @@ jobs:
       - name: Generate CycloneDX SBOM
         run: mvn -B cyclonedx:makeAggregateBom
 
-      - name: Write project metadata
-        run: |
-          set -euo pipefail
-          {
-            echo "PROJECT_NAME=github.com/${{ github.repository }}"
-            echo "PROJECT_VERSION=${{ github.sha }}"
-          } > project.env
-
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@v7.0.1
         with:
           name: sbom
           if-no-files-found: error
-          path: |
-            target/sbom.cdx.json
-            project.env
+          path: target/sbom.cdx.json
 
   upload:
     needs: sbom
@@ -72,16 +66,6 @@ jobs:
         uses: actions/download-artifact@v8.0.1
         with:
           name: sbom
-
-      - name: Load project metadata
-        id: meta
-        run: |
-          set -euo pipefail
-          set -a
-          . ./project.env
-          set +a
-          echo "name=${PROJECT_NAME}" >> "$GITHUB_OUTPUT"
-          echo "version=${PROJECT_VERSION}" >> "$GITHUB_OUTPUT"
 
       - name: Fetch DT API key from OpenBao
         id: bao
@@ -99,12 +83,14 @@ jobs:
       - name: Upload SBOM to Dependency-Track
         env:
           DT_API_KEY: ${{ steps.bao.outputs.DT_API_KEY }}
+          PROJECT_NAME: github.com/${{ github.repository }}
+          PROJECT_VERSION: ${{ github.sha }}
         run: |
           set -euo pipefail
           curl -fsS -X POST http://dependency-track-api-server.dependency-track.svc.cluster.local:8080/api/v1/bom \
             -H "X-Api-Key: ${DT_API_KEY}" \
             -F "autoCreate=true" \
-            -F "projectName=${{ steps.meta.outputs.name }}" \
-            -F "projectVersion=${{ steps.meta.outputs.version }}" \
+            -F "projectName=${PROJECT_NAME}" \
+            -F "projectVersion=${PROJECT_VERSION}" \
             -F "isLatest=true" \
-            -F "bom=@target/sbom.cdx.json"
+            -F "bom=@sbom.cdx.json"


### PR DESCRIPTION
Follow-up to the SBOM pilot: applies the same hardening the four `homebridge-*` PRs got after review.

**Problem:** the `upload` job ran `. ./project.env` — i.e. it *sourced* a file produced by the untrusted `sbom` job (which runs the Maven build/plugins) **on the in-cluster runner**. That executes attacker-influenceable content and undermines the two-job isolation that keeps untrusted code off the cluster runner.

**Fix:** derive `projectName`/`projectVersion` in the upload job from trusted GitHub context (`github.repository` / `github.sha`) via `env:`; drop `project.env` entirely. The artifact now carries only `sbom.cdx.json` (single-file artifact extracts to the workspace root, so `bom=@sbom.cdx.json`).

No behavior change to what's uploaded (same project name/version values, same SBOM); purely removes the code-execution path. Mirrors homebridge-onkyo#191 / -philips-hue-sync-box#396 / -playstation#193 / -smartrent#274.