### PR TITLE
fix: back off unhealthy pods so they stop starving healthy leaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ to a status file (typically on a shared `emptyDir`) and refreshes it; the electo
 - **Deadlock escape hatch:** if the lock is free but *no* pod is healthy (fresh install, total
   outage), after `ELECTOR_HEALTH_PROBE_DEADLOCK_GRACE` a pod acquires it anyway and leads in a
   logged "degraded" state, rather than leaving the system leaderless forever.
+- **Unhealthy backoff:** an unhealthy pod still re-probes for the lock (to feed the deadlock escape
+  hatch), but on the longer `ELECTOR_HEALTH_PROBE_UNHEALTHY_BACKOFF` interval rather than the tight
+  `ELECTOR_RETRY_PERIOD`. Without this, an unhealthy ex-leader re-grabbing the free lock every retry
+  period and releasing it starves the healthy peers racing to take over — a livelock that leaves the
+  deployment leaderless until the unhealthy pod happens to recover.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -45,5 +50,6 @@ to a status file (typically on a shared `emptyDir`) and refreshes it; the electo
 | `ELECTOR_HEALTH_PROBE_MAX_AGE` | `2m` | Reject the file if not updated within this window (`0` disables) |
 | `ELECTOR_HEALTH_PROBE_FAILURE_THRESHOLD` | `3` | Consecutive failures tolerated while leading |
 | `ELECTOR_HEALTH_PROBE_DEADLOCK_GRACE` | `5m` | How long to wait before leading degraded when no pod is healthy |
+| `ELECTOR_HEALTH_PROBE_UNHEALTHY_BACKOFF` | `30s` | Re-probe interval for an unhealthy pod (keeps it from starving healthy peers) |
 
 

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorProperties.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorProperties.java
@@ -67,4 +67,14 @@ public class ElectorProperties {
     // pod-unhealthy for this long, acquire it anyway and lead in a degraded state.
     @NotNull
     private Duration healthProbeDeadlockGrace = Duration.ofMinutes(5);
+
+    // How long an UNHEALTHY pod backs off before re-probing for leadership, instead of the tight
+    // retryPeriod a healthy pod uses. An unhealthy ex-leader that keeps re-acquiring the free lock
+    // every retryPeriod (to test eligibility) and releasing it starves the healthy peers that are
+    // trying to take over — a livelock that leaves the deployment leaderless. Backing off well past
+    // retryPeriod gives healthy peers uncontested acquisition windows so one of them leads promptly.
+    // Should comfortably exceed retryPeriod; well under healthProbeDeadlockGrace so the all-unhealthy
+    // escape hatch still fires on time (the unhealthy pod still re-probes ~grace/backoff times).
+    @NotNull
+    private Duration healthProbeUnhealthyBackoff = Duration.ofSeconds(30);
 }

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorService.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorService.java
@@ -125,19 +125,31 @@ public class ElectorService implements SmartLifecycle {
                     becomeLeader(newLock);
                 } else {
                     // Lock is free but we're unhealthy and still within the grace window. Don't
-                    // lead yet — release so a healthy peer can take over — and back off well past
-                    // retryPeriod. Retrying on the tight retryPeriod here re-grabs the free lock every
-                    // few seconds and starves the healthy peers racing for it (a livelock that leaves
-                    // the deployment leaderless); the longer backoff yields uncontested windows.
-                    log.info("Lock '{}' is free but this pod fails its health probe; not eligible to lead yet, " +
-                             "releasing and backing off {} so a healthy peer can lead",
-                             electorProperties.getLockName(), electorProperties.getHealthProbeUnhealthyBackoff());
+                    // lead yet — release so a healthy peer can take over.
+                    boolean released = true;
                     try {
                         newLock.unlock();
                     } catch (final Exception e) {
+                        released = false;
                         log.error("Error releasing transiently held lock", e);
                     }
-                    scheduleUnhealthyRetry();
+                    if (released) {
+                        // Released cleanly: back off well past retryPeriod so we stop re-grabbing the
+                        // free lock every few seconds and starving the healthy peers racing for it (the
+                        // livelock that leaves the deployment leaderless); the backoff yields them
+                        // uncontested windows.
+                        log.info("Lock '{}' is free but this pod fails its health probe; released and " +
+                                 "backing off {} so a healthy peer can lead",
+                                 electorProperties.getLockName(), electorProperties.getHealthProbeUnhealthyBackoff());
+                        scheduleUnhealthyRetry();
+                    } else {
+                        // Release failed, so we may still hold the lock — backing off the long interval
+                        // would keep healthy peers blocked. Re-probe on the short retryPeriod to retry
+                        // the release promptly instead.
+                        log.warn("Lock '{}' may still be held after a failed release; retrying in {} to release it",
+                                 electorProperties.getLockName(), electorProperties.getRetryPeriod());
+                        scheduleRetry();
+                    }
                 }
             } else {
                 // Someone else holds the lock: a leader exists, so we are not deadlocked.

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorService.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorService.java
@@ -125,21 +125,33 @@ public class ElectorService implements SmartLifecycle {
                     becomeLeader(newLock);
                 } else {
                     // Lock is free but we're unhealthy and still within the grace window. Don't
-                    // lead yet — release so a healthy peer can take over — and retry.
+                    // lead yet — release so a healthy peer can take over — and back off well past
+                    // retryPeriod. Retrying on the tight retryPeriod here re-grabs the free lock every
+                    // few seconds and starves the healthy peers racing for it (a livelock that leaves
+                    // the deployment leaderless); the longer backoff yields uncontested windows.
                     log.info("Lock '{}' is free but this pod fails its health probe; not eligible to lead yet, " +
-                             "releasing and retrying", electorProperties.getLockName());
+                             "releasing and backing off {} so a healthy peer can lead",
+                             electorProperties.getLockName(), electorProperties.getHealthProbeUnhealthyBackoff());
                     try {
                         newLock.unlock();
                     } catch (final Exception e) {
                         log.error("Error releasing transiently held lock", e);
                     }
-                    scheduleRetry();
+                    scheduleUnhealthyRetry();
                 }
             } else {
                 // Someone else holds the lock: a leader exists, so we are not deadlocked.
                 deadlockSince.set(null);
-                log.info("Could not acquire lock, will retry in {}", electorProperties.getRetryPeriod());
-                scheduleRetry();
+                // An unhealthy pod still backs off the longer interval: it has no business racing for
+                // leadership, and a tight retry only adds churn while a leader already exists.
+                if (healthy) {
+                    log.info("Could not acquire lock, will retry in {}", electorProperties.getRetryPeriod());
+                    scheduleRetry();
+                } else {
+                    log.info("Could not acquire lock (a leader exists); unhealthy, will retry in {}",
+                             electorProperties.getHealthProbeUnhealthyBackoff());
+                    scheduleUnhealthyRetry();
+                }
             }
         } catch (final InterruptedException e) {
             Thread
@@ -192,6 +204,17 @@ public class ElectorService implements SmartLifecycle {
                                    clock
                                            .instant()
                                            .plus(electorProperties.getRetryPeriod()));
+        }
+    }
+
+    // Re-probe schedule for an UNHEALTHY pod: a longer backoff than retryPeriod so it stops
+    // contending for the lock every few seconds and lets healthy peers take over (see lockLoop).
+    private void scheduleUnhealthyRetry() {
+        if (running.get()) {
+            taskScheduler.schedule(this::lockLoop,
+                                   clock
+                                           .instant()
+                                           .plus(electorProperties.getHealthProbeUnhealthyBackoff()));
         }
     }
 

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorPropertiesTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorPropertiesTest.java
@@ -55,6 +55,7 @@ class ElectorPropertiesTest {
         assertEquals(Duration.ofMinutes(2), properties.getHealthProbeMaxAge());
         assertEquals(3, properties.getHealthProbeFailureThreshold());
         assertEquals(Duration.ofMinutes(5), properties.getHealthProbeDeadlockGrace());
+        assertEquals(Duration.ofSeconds(30), properties.getHealthProbeUnhealthyBackoff());
     }
 
     @Test
@@ -271,6 +272,28 @@ class ElectorPropertiesTest {
                                    .getPropertyPath()
                                    .toString()
                                    .equals("retryPeriod")));
+    }
+
+    @Test
+    void shouldFailValidationWhenHealthProbeUnhealthyBackoffIsNull() {
+        // Given
+        final ElectorProperties properties = new ElectorProperties();
+        properties.setLabelKey("test-label");
+        properties.setLockName("test-lock");
+        properties.setSelectorLabelValue("test-app");
+        properties.setHealthProbeUnhealthyBackoff(null);
+
+        // When
+        final Set<ConstraintViolation<ElectorProperties>> violations = validator.validate(properties);
+
+        // Then
+        assertFalse(violations.isEmpty());
+        assertTrue(violations
+                           .stream()
+                           .anyMatch(v -> v
+                                   .getPropertyPath()
+                                   .toString()
+                                   .equals("healthProbeUnhealthyBackoff")));
     }
 
     @Test

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorServiceTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorServiceTest.java
@@ -350,6 +350,41 @@ class ElectorServiceTest {
     }
 
     @Test
+    void lockLoop_unhealthyFreeLock_whenReleaseFails_retriesSoonNotLongBackoff() throws Exception {
+        // Given: unhealthy, lock free (acquired), within grace, but releasing it throws. We may still
+        // hold the lock, so re-probe on the short retryPeriod (5s) to retry the release rather than
+        // sit on the long unhealthy backoff (30s) while healthy peers stay blocked.
+        when(healthProbe.isHealthy()).thenReturn(false);
+        lenient()
+                .when(electorProperties.getHealthProbeDeadlockGrace())
+                .thenReturn(Duration.ofMinutes(5));
+        when(lockRegistry.obtain("test-lock")).thenReturn(lock);
+        when(lock.tryLock(5L, TimeUnit.SECONDS)).thenReturn(true);
+        doThrow(new IllegalStateException("redis blip releasing lock"))
+                .when(lock)
+                .unlock();
+
+        electorService.start();
+        final ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler).schedule(runnableCaptor.capture(), any(Instant.class));
+
+        // When
+        runnableCaptor
+                .getValue()
+                .run();
+
+        // Then: it re-probes on retryPeriod (5s), not the unhealthy backoff (30s).
+        verify(callbacks, never()).onLockAcquired();
+        verify(lock).unlock();
+        final ArgumentCaptor<Instant> whenCaptor = ArgumentCaptor.forClass(Instant.class);
+        verify(taskScheduler, times(2)).schedule(any(Runnable.class), whenCaptor.capture());
+        final Instant t0 = Instant.parse("2026-01-01T00:00:00Z");
+        assertEquals(t0.plus(Duration.ofSeconds(5)), whenCaptor
+                .getAllValues()
+                .get(1));
+    }
+
+    @Test
     void lockLoop_shouldBackOffNotTightRetryWhenUnhealthyAndLeaderExists() throws Exception {
         // Given: a leader already exists (lock not acquirable) and this pod is unhealthy.
         when(healthProbe.isHealthy()).thenReturn(false);

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorServiceTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorServiceTest.java
@@ -84,6 +84,9 @@ class ElectorServiceTest {
         lenient()
                 .when(electorProperties.getLeaseDuration())
                 .thenReturn(Duration.ofSeconds(120));
+        lenient()
+                .when(electorProperties.getHealthProbeUnhealthyBackoff())
+                .thenReturn(Duration.ofSeconds(30));
     }
 
     @Test
@@ -332,11 +335,70 @@ class ElectorServiceTest {
                 .getValue()
                 .run();
 
-        // Then: it does not lead, releases the transiently-held lock, and retries
+        // Then: it does not lead, releases the transiently-held lock, and re-probes — but on the
+        // longer unhealthy backoff (30s), NOT the tight retryPeriod (5s). Re-grabbing the free lock
+        // every retryPeriod is exactly the livelock that starves the healthy peers racing for it.
         verify(callbacks, never()).onLockAcquired();
         verify(lock).unlock();
         verify(taskScheduler, never()).scheduleAtFixedRate(any(Runnable.class), any(Instant.class), any(Duration.class));
-        verify(taskScheduler, times(2)).schedule(any(Runnable.class), any(Instant.class));
+        final ArgumentCaptor<Instant> whenCaptor = ArgumentCaptor.forClass(Instant.class);
+        verify(taskScheduler, times(2)).schedule(any(Runnable.class), whenCaptor.capture());
+        final Instant t0 = Instant.parse("2026-01-01T00:00:00Z");
+        assertEquals(t0.plus(Duration.ofSeconds(30)), whenCaptor
+                .getAllValues()
+                .get(1));
+    }
+
+    @Test
+    void lockLoop_shouldBackOffNotTightRetryWhenUnhealthyAndLeaderExists() throws Exception {
+        // Given: a leader already exists (lock not acquirable) and this pod is unhealthy.
+        when(healthProbe.isHealthy()).thenReturn(false);
+        when(lockRegistry.obtain("test-lock")).thenReturn(lock);
+        when(lock.tryLock(5L, TimeUnit.SECONDS)).thenReturn(false);
+
+        electorService.start();
+        final ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler).schedule(runnableCaptor.capture(), any(Instant.class));
+
+        // When
+        runnableCaptor
+                .getValue()
+                .run();
+
+        // Then: an unhealthy pod has no business racing for leadership, so it re-probes on the
+        // longer backoff (30s) rather than the retryPeriod (5s) a healthy pod would use here.
+        verify(callbacks, never()).onLockAcquired();
+        final ArgumentCaptor<Instant> whenCaptor = ArgumentCaptor.forClass(Instant.class);
+        verify(taskScheduler, times(2)).schedule(any(Runnable.class), whenCaptor.capture());
+        final Instant t0 = Instant.parse("2026-01-01T00:00:00Z");
+        assertEquals(t0.plus(Duration.ofSeconds(30)), whenCaptor
+                .getAllValues()
+                .get(1));
+    }
+
+    @Test
+    void lockLoop_shouldUseRetryPeriodWhenHealthyAndLeaderExists() throws Exception {
+        // Given: healthy (default) and a leader already exists.
+        when(lockRegistry.obtain("test-lock")).thenReturn(lock);
+        when(lock.tryLock(5L, TimeUnit.SECONDS)).thenReturn(false);
+
+        electorService.start();
+        final ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler).schedule(runnableCaptor.capture(), any(Instant.class));
+
+        // When
+        runnableCaptor
+                .getValue()
+                .run();
+
+        // Then: a healthy contender keeps re-probing on the tight retryPeriod (5s) so it takes over
+        // promptly the moment the lock frees — the backoff is only for unhealthy pods.
+        final ArgumentCaptor<Instant> whenCaptor = ArgumentCaptor.forClass(Instant.class);
+        verify(taskScheduler, times(2)).schedule(any(Runnable.class), whenCaptor.capture());
+        final Instant t0 = Instant.parse("2026-01-01T00:00:00Z");
+        assertEquals(t0.plus(Duration.ofSeconds(5)), whenCaptor
+                .getAllValues()
+                .get(1));
     }
 
     @Test


### PR DESCRIPTION
## Problem

A single unhealthy pod could leave the whole deployment **leaderless for ~40 minutes**.

Observed live on the Pi-hole fleet (2026-06-09): pihole-2 (the leader) restarted, its health probe went unhealthy, and it relinquished leadership after the failure threshold. Then **two healthy peers could not acquire the free lock** until pihole-2 happened to recover ~40 min later. During that window the leader-backed `pihole-leader` Service had zero endpoints → the gateway 503'd `pihole.jaredbrown.io`, and `nebula-sync` refused (`no Pi-hole leader pod is labeled`), firing `BlackboxProbeFailed`, `PiholeSyncRefused`, `PiholeSyncNotSucceeding`, and `KubeJobFailed`.

## Root cause

`ElectorService.lockLoop()` re-probes on the tight `retryPeriod` (5s) regardless of health. An unhealthy ex-leader therefore looped: `tryLock` the free lock → it's healthy? no → release → `scheduleRetry()` in 5s → repeat. That grab-and-release every 5s **starved the healthy peers** racing for the same lock — a livelock, not a wiped DB or a fleet-wide health outage (both peers reported `healthy=true` the entire time).

## Fix

Unhealthy pods still re-probe (the deadlock escape hatch needs to know whether the lock is free), but on a longer, configurable backoff instead of the tight retry period:

- New `ELECTOR_HEALTH_PROBE_UNHEALTHY_BACKOFF` (default **30s**), applied on both unhealthy non-leading branches (free-lock-within-grace and leader-exists).
- Healthy contenders keep the tight `retryPeriod` so they take over promptly the instant the lock frees.
- The deadlock escape hatch is unaffected — an unhealthy pod still re-probes ~`grace / backoff` times before leading degraded.

Net effect: the unhealthy pod steps aside for 30s; healthy peers (retrying every 5s) acquire within one cycle → recovery in seconds instead of dozens of minutes.

### Deliberately *not* changed
- Kept the blocking `tryLock` rather than switching the unhealthy probe to non-blocking `tryLock(0)`: the backoff alone deterministically fixes the starvation, while `tryLock(0)` adds `RedisLockRegistry` version-semantics risk for marginal gain.
- The pre-existing multi-pod *all-unhealthy* ping-pong is out of scope (covered downstream by the Pi-hole sync-guard + teleporter restore).

## Tests
`mvn test` green — 46 tests, 0 failures. Added/updated:
- `ElectorServiceTest`: unhealthy + free-lock reschedules at `now + backoff` (not retryPeriod); unhealthy + leader-exists uses backoff; healthy + leader-exists still uses retryPeriod.
- `ElectorPropertiesTest`: default `30s` + `@NotNull` validation.

## Rollout
After merge + a new tag (e.g. `v2.1.2`), bump the image pin in homelab `argocd/values/networking/dns/pihole.yaml` (`v2.1.1` → new tag). The property defaults safely, so the bump alone is sufficient; the probe is unchanged when health-gating is disabled.