### PR TITLE
ci: sign release image with cosign (keyless)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,10 +75,19 @@ jobs:
 
     - name: Install cosign
       uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+      with:
+        # Pin the cosign binary (not just the installer) so signature/bundle
+        # format stays stable and Kyverno verification is reproducible.
+        cosign-release: 'v3.1.1'
 
     # Keyless (Fulcio/rekor) signature over the pushed digest so the homelab
     # Kyverno verify-ghcr-images policy can verify this image.
     - name: Sign image (keyless)
       env:
         DIGEST: ${{ steps.image.outputs.digest }}
-      run: cosign sign --yes "ghcr.io/${{ github.repository_owner }}/k8s-leader-elector@${DIGEST}"
+      run: |
+        if [ -z "${DIGEST}" ]; then
+          echo "::error::build-push-action produced no digest; cannot sign image" >&2
+          exit 1
+        fi
+        cosign sign --yes "ghcr.io/${{ github.repository_owner }}/k8s-leader-elector@${DIGEST}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
       run: mvn clean install
 
     - name: Build and push Docker image
+      id: image
       uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
       with:
         context: .
@@ -71,3 +72,13 @@ jobs:
           ghcr.io/${{ github.repository_owner }}/k8s-leader-elector:latest
         cache-from: type=gha
         cache-to: type=gha,mode=max
+
+    - name: Install cosign
+      uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+    # Keyless (Fulcio/rekor) signature over the pushed digest so the homelab
+    # Kyverno verify-ghcr-images policy can verify this image.
+    - name: Sign image (keyless)
+      env:
+        DIGEST: ${{ steps.image.outputs.digest }}
+      run: cosign sign --yes "ghcr.io/${{ github.repository_owner }}/k8s-leader-elector@${DIGEST}"


### PR DESCRIPTION
Adds a keyless cosign signature to the release image so the homelab cluster can verify it.

## Why

The build already runs with `id-token: write` and pushes to `ghcr.io/jabrown93/…`, but pushed the image **unsigned**. The homelab Kyverno `verify-ghcr-images` `ImageValidatingPolicy` verifies cosign keyless signatures (Fulcio issuer `token.actions.githubusercontent.com`, rekor), so this image currently fails verification (Audit mode) and blocks flipping that policy to enforce.

## Change

- `id: image` on the build-push step to expose the pushed digest.
- `sigstore/cosign-installer` (SHA-pinned) + `cosign sign --yes <repo>@${digest}` — keyless, signs the multi-arch index digest. cosign v3 default (new Sigstore bundle / OCI 1.1 referrer), which Kyverno 1.18 verifies.

No change to the image contents; it just gains a signature. Takes effect on the next tagged release. The homelab policy is being extended in parallel to trust this repo’s `release.yml@refs/tags/v*` identity.
