### PR TITLE
fix: reconcile leader labels on every renewal and fix cross-thread lock release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -174,6 +174,28 @@ query failure is likewise logged and retried on the next reconcile rather than e
 means a slow API server, or a pod created after the last election, self-heals within one
 `renewDeadline` instead of staying wrong until the next leadership change.
 
+Before mutating each drifted pod, `reconcileLeaderLabels()` re-confirms leadership via a
+`stillLeader` callback (`ElectorService#stillOwnsLock`, which calls `RedisLockRegistry.renewLock` —
+a Redis-side ownership check whose Lua script only succeeds while Redis still maps the key to this
+registry's client id, and which refreshes the lease as a side effect). This closes a TOCTOU: a
+reconcile that outlives the lease (very slow API, many drifted pods) must not keep stamping this
+pod's stale identity after another pod has already taken over the lock — that would flip the new
+leader's label back to `false` and leave the deployment momentarily leaderless. On a lost/unconfirmed
+ownership the reconcile halts immediately; labels then converge on the new leader's next reconcile.
+The check only fires for pods that actually need a patch, so a steady-state (all-labels-match)
+reconcile issues no extra Redis calls.
+
+### Kubernetes Client Request Bounds
+
+`K8sClientConfiguration` overrides two fabric8 defaults on the `KubernetesClient` bean:
+`requestTimeout` (10s → 2.5s) and `requestRetryBackoffLimit` (10 → 3). Every K8s API call runs
+inline on `ElectorService`'s single scheduler thread, so an unbounded call would (a) block the
+shutdown-time lock release past its 5s `RELEASE_TIMEOUT` window and (b) in the extreme stall lock
+renewal past the lease while a label reconcile is mid-flight. Bounding the per-call time keeps a whole
+reconcile of a handful of pods comfortably inside both windows. The config starts from
+`Config.autoConfigure(null)` (in-cluster service-account token, API server, CA, namespace) and edits
+only those two fields, so authentication is untouched.
+
 ### Thread Safety
 
 - `ElectorService`'s `TaskScheduler` bean is pinned to a single thread (`setPoolSize(1)` in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,4 +192,13 @@ means a slow API server, or a pod created after the last election, self-heals wi
   release onto the scheduler (`taskScheduler.submit(...)`) and blocks on the returned `Future` for
   up to 5 seconds (`ElectorService.RELEASE_TIMEOUT`) so the unlock happens on the correct thread
   before the pod terminates
+- `TaskSchedulerConfiguration` sets `acceptTasksAfterContextClose(true)` on the scheduler bean. This
+  is required, not cosmetic: `ThreadPoolTaskScheduler` listens for `ContextClosedEvent` and, by
+  default, calls `executor.shutdown()` right there — and that event is published (synchronously)
+  *before* Spring invokes any `SmartLifecycle#stop()`. Without the flag, `stop()`'s `submit()` call
+  above would always throw `TaskRejectedException` and the lock would leak every graceful shutdown —
+  exactly the bug this scheduler thread-pinning exists to avoid
+- If this pod was leading, `stop()` also clears its own `leader=true` label (`callbacks.onShutdown()`)
+  after releasing the lock, so it doesn't sit labeled true for the rest of
+  `terminationGracePeriodSeconds`
 - Spring Boot graceful shutdown ensures in-flight operations complete

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,8 @@ This is a Kubernetes leader election sidecar application that:
 
 - Acquires distributed leadership using Redis-based locks (via Spring Integration)
 - Labels the leader Pod with a configurable label (default: `dns.jb.io/leader=true`)
-- Manages label state on leadership changes across all Pods in the StatefulSet/Deployment
+- Manages label state on leadership changes across all Pods in the StatefulSet/Deployment,
+  re-reconciling it on every lock renewal so a missed or late-created pod self-heals
 
 **Status**: Under active development, bugs are likely.
 
@@ -62,8 +63,12 @@ The application requires:
 
 - Implements Spring `SmartLifecycle` to manage distributed lock lifecycle
 - Uses `RedisLockRegistry` from Spring Integration for distributed locking
+- On `start()`, labels self `leader=false` (`callbacks.ensureSelfLabeled()`) before the first
+  acquisition attempt, so a freshly (re)created pod never sits unlabeled
 - Lock acquisition loop with configurable retry period
-- Automatic lock renewal via scheduled executor at `renewDeadline` interval
+- Automatic lock renewal via scheduled executor at `renewDeadline` interval; a failed renew is
+  retried once immediately before the lock is treated as lost (absorbs a single transient Redis
+  blip). A successful renew also re-runs `callbacks.reconcileLeaderLabels()`
 - Handles lock loss and attempts reacquisition automatically
 - Optional health gating (when `healthProbeEnabled`): an unhealthy pod won't acquire the lock
   (eligibility gate in `lockLoop`), and a leader that goes unhealthy relinquishes after
@@ -80,9 +85,16 @@ The application requires:
 
 **LockCallbacks** (`src/main/java/io/jaredbrown/k8s/leader/elector/LockCallbacks.java`)
 
-- Executed by ElectorService on lock state changes
-- `onLockAcquired()`: Labels all pods with matching `app` label, setting leader=true on self
-- `onLockLost()`: Removes leader label from self
+- Executed by ElectorService on lock state changes and on every successful renewal
+- `reconcileLeaderLabels()`: idempotent — lists all pods with the matching selector label and
+  patches only those whose label differs from the desired value (leader=true on self, =false on
+  everyone else). Never throws; a labeling failure is logged and retried on the next reconcile
+  (acquisition, or the next renewal tick at most `renewDeadline` later) rather than costing
+  leadership.
+- `onLockAcquired()`: delegates to `reconcileLeaderLabels()`
+- `ensureSelfLabeled()`: called once on startup so a freshly (re)created pod carries the label from
+  boot instead of staying unlabeled until its first election
+- `onLockLost()`: removes leader label from self
 - Uses Fabric8 Kubernetes client to patch Pod labels
 
 **RedisLockRegistryConfiguration** (
@@ -103,12 +115,16 @@ Configuration properties (prefix: `elector`):
 
 ### Lifecycle Flow
 
-1. **Startup**: ElectorService starts via SmartLifecycle (phase: Integer.MIN_VALUE for early start)
+1. **Startup**: ElectorService starts via SmartLifecycle (phase: Integer.MIN_VALUE for early start);
+   labels self `leader=false` before the first acquisition attempt
 2. **Lock Acquisition**: Attempts to acquire lock from Redis, retries every `retryPeriod`
 3. **Leadership**: On acquisition, schedules lock renewal task and calls `onLockAcquired()`
-4. **Lock Maintenance**: Renews lock every `renewDeadline` seconds
-5. **Lock Loss**: If renewal fails or lock lost, calls `onLockLost()` and re-enters acquisition loop
-6. **Shutdown**: PreDestroy hook releases lock gracefully
+   (reconciles leader labels)
+4. **Lock Maintenance**: Renews lock every `renewDeadline` seconds (one immediate retry on a failed
+   renew), then re-reconciles leader labels
+5. **Lock Loss**: If renewal fails (after its retry) or lock lost, calls `onLockLost()` and
+   re-enters acquisition loop
+6. **Shutdown**: PreDestroy hook cancels renewal and releases the lock via the scheduler thread
 
 ### Key Dependencies
 
@@ -143,25 +159,37 @@ See `src/main/resources/application.properties`:
 
 ### Pod Labeling Strategy
 
-On lock acquisition, the service ensures exactly one pod has the leader label:
+`reconcileLeaderLabels()` brings every pod's label in line with the current election result, and is
+called both on acquisition and on every successful renewal (not a one-shot):
 
 1. Queries all Pods with label `app={elector.appName}`
-2. Updates all pods atomically:
-    - Sets `{elector.labelKey}=true` on the current pod (new leader)
-    - Sets `{elector.labelKey}=false` on all other pods (former leaders)
+2. For each pod whose current `{elector.labelKey}` value doesn't already match the desired one:
+    - Sets `{elector.labelKey}=true` on the current pod (leader)
+    - Sets `{elector.labelKey}=false` on every other pod
+3. Pods whose label already matches are skipped (idempotent — safe to call every renewal tick)
 
-This two-phase approach ensures only one pod has the leader label at any given time.
-Individual pod label update failures are logged but don't prevent updating other pods.
-The entire operation fails only if the initial pod list query fails.
+Individual pod label update failures are logged but don't prevent updating other pods, and never
+throw: a labeling problem is a side effect of leadership, not a reason to give it up. A pod list
+query failure is likewise logged and retried on the next reconcile rather than escalated. This
+means a slow API server, or a pod created after the last election, self-heals within one
+`renewDeadline` instead of staying wrong until the next leadership change.
 
 ### Thread Safety
 
-- `ElectorService` uses a single-threaded ScheduledExecutorService
-- Lock state is managed via volatile fields
+- `ElectorService`'s `TaskScheduler` bean is pinned to a single thread (`setPoolSize(1)` in
+  `TaskSchedulerConfiguration`) specifically because `DistributedLock.unlock()` is thread-owned
+  (`RedisLockRegistry.RedisLock` wraps a local `ReentrantLock` and throws `IllegalStateException` if
+  unlocked from a different thread than acquired it). Pinning to one thread keeps acquisition
+  (`lockLoop`) and renewal/release (`refreshLock`) on the same thread by construction.
+- Lock state is managed via volatile/atomic fields
 - Lock acquisition and renewal happen sequentially, never concurrently
 
 ### Graceful Shutdown
 
-- `@PreDestroy` annotation ensures lock release on pod termination
-- Scheduler waits up to 5 seconds for clean shutdown
+- `@PreDestroy` → `stop()` cancels the refresh task, then releases the lock
+- Since `stop()` itself runs on whatever thread Spring's context shutdown uses (not the scheduler
+  thread), it can't call `unlock()` directly — see Thread Safety above. Instead it submits the
+  release onto the scheduler (`taskScheduler.submit(...)`) and blocks on the returned `Future` for
+  up to 5 seconds (`ElectorService.RELEASE_TIMEOUT`) so the unlock happens on the correct thread
+  before the pod terminates
 - Spring Boot graceful shutdown ensures in-flight operations complete

--- a/README.md
+++ b/README.md
@@ -5,7 +5,10 @@
 Tiny Kubernetes sidecar binary that:
 
 - Acquires leadership using a Redis distributed lock (Spring Integration `RedisLockRegistry`)
-- On gaining leadership, patches its own Pod with a label (default: `dns.jb.io/leader=true`)
+- On gaining leadership, patches its own Pod with a label (default: `dns.jb.io/leader=true`) and
+  every other matching pod with `=false`
+- Re-reconciles that labeling on every lock renewal (not just on acquisition), so a pod created or
+  missed after the last election catches up within one `ELECTOR_RENEW_DEADLINE`
 - On losing leadership, removes the label
 
 ## Configuration

--- a/src/main/java/io/jaredbrown/k8s/leader/configuration/K8sClientConfiguration.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/configuration/K8sClientConfiguration.java
@@ -16,8 +16,8 @@ public class K8sClientConfiguration {
     // extreme, stall lock renewal past the lease while a label reconcile is in flight. Bound both so a
     // whole leader-label reconcile of a handful of pods finishes well inside the release window and
     // the lease, keeping the scheduler thread responsive.
-    private static final int REQUEST_TIMEOUT_MILLIS = 2500;
-    private static final int REQUEST_RETRY_BACKOFF_LIMIT = 3;
+    private static final int REQUEST_TIMEOUT_MILLIS = 2000;
+    private static final int REQUEST_RETRY_BACKOFF_LIMIT = 1
 
     @Bean(destroyMethod = "close")
     public KubernetesClient kubernetesClient() {

--- a/src/main/java/io/jaredbrown/k8s/leader/configuration/K8sClientConfiguration.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/configuration/K8sClientConfiguration.java
@@ -1,5 +1,7 @@
 package io.jaredbrown.k8s.leader.configuration;
 
+import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import org.springframework.context.annotation.Bean;
@@ -7,8 +9,26 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class K8sClientConfiguration {
+    // fabric8 defaults to a 10s per-request timeout and up to 10 retries
+    // (Config.DEFAULT_REQUEST_TIMEOUT / DEFAULT_REQUEST_RETRY_BACKOFFLIMIT). ElectorService drives
+    // every Kubernetes call inline on its single scheduler thread, so an unbounded call would
+    // (a) block the shutdown-time lock release past its 5s window (RELEASE_TIMEOUT) and (b) in the
+    // extreme, stall lock renewal past the lease while a label reconcile is in flight. Bound both so a
+    // whole leader-label reconcile of a handful of pods finishes well inside the release window and
+    // the lease, keeping the scheduler thread responsive.
+    private static final int REQUEST_TIMEOUT_MILLIS = 2500;
+    private static final int REQUEST_RETRY_BACKOFF_LIMIT = 3;
+
     @Bean(destroyMethod = "close")
     public KubernetesClient kubernetesClient() {
-        return new KubernetesClientBuilder().build();
+        // Start from the environment-derived config (in-cluster service-account token, API server, CA,
+        // namespace) so auth is untouched, then override only the request bounds.
+        final Config config = new ConfigBuilder(Config.autoConfigure(null))
+                .withRequestTimeout(REQUEST_TIMEOUT_MILLIS)
+                .withRequestRetryBackoffLimit(REQUEST_RETRY_BACKOFF_LIMIT)
+                .build();
+        return new KubernetesClientBuilder()
+                .withConfig(config)
+                .build();
     }
 }

--- a/src/main/java/io/jaredbrown/k8s/leader/configuration/K8sClientConfiguration.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/configuration/K8sClientConfiguration.java
@@ -17,7 +17,7 @@ public class K8sClientConfiguration {
     // whole leader-label reconcile of a handful of pods finishes well inside the release window and
     // the lease, keeping the scheduler thread responsive.
     private static final int REQUEST_TIMEOUT_MILLIS = 2000;
-    private static final int REQUEST_RETRY_BACKOFF_LIMIT = 1
+    private static final int REQUEST_RETRY_BACKOFF_LIMIT = 1;
 
     @Bean(destroyMethod = "close")
     public KubernetesClient kubernetesClient() {

--- a/src/main/java/io/jaredbrown/k8s/leader/configuration/TaskSchedulerConfiguration.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/configuration/TaskSchedulerConfiguration.java
@@ -3,7 +3,6 @@ package io.jaredbrown.k8s.leader.configuration;
 import jakarta.annotation.Nonnull;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import java.time.Clock;
@@ -12,9 +11,13 @@ import java.time.Clock;
 public class TaskSchedulerConfiguration {
     @Nonnull
     @Bean
-    public TaskScheduler taskScheduler() {
+    public ThreadPoolTaskScheduler taskScheduler() {
         final ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-        scheduler.setPoolSize(2);
+        // DistributedLock.unlock() is thread-owned (see ElectorService#awaitLockRelease): a pool
+        // size above 1 lets lock acquisition (lockLoop) and renewal/release (refreshLock) run on
+        // different worker threads, which throws IllegalStateException off the acquiring thread. A
+        // single thread keeps every lock operation sequential and on the same thread by construction.
+        scheduler.setPoolSize(1);
         scheduler.setThreadNamePrefix("elector-");
         scheduler.setDaemon(true);
         scheduler.initialize();

--- a/src/main/java/io/jaredbrown/k8s/leader/configuration/TaskSchedulerConfiguration.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/configuration/TaskSchedulerConfiguration.java
@@ -20,6 +20,16 @@ public class TaskSchedulerConfiguration {
         scheduler.setPoolSize(1);
         scheduler.setThreadNamePrefix("elector-");
         scheduler.setDaemon(true);
+        // ExecutorConfigurationSupport listens for ContextClosedEvent and, by default, calls
+        // executor.shutdown() right there - which is published (and handled synchronously) BEFORE
+        // Spring invokes any SmartLifecycle#stop() (see AbstractApplicationContext#doClose: the
+        // ContextClosedEvent publish precedes lifecycleProcessor.onClose()). Since ElectorService's
+        // own stop() submits the shutdown-time lock release to this same scheduler, without this
+        // flag that submit() would always throw TaskRejectedException and the lock would leak every
+        // graceful shutdown - the exact bug this scheduler exists to avoid. Setting this defers the
+        // executor's shutdown to its later @PreDestroy/DisposableBean callback, which runs after all
+        // SmartLifecycle beans have stopped.
+        scheduler.setAcceptTasksAfterContextClose(true);
         scheduler.initialize();
         return scheduler;
     }

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorService.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorService.java
@@ -7,7 +7,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.integration.redis.util.RedisLockRegistry;
 import org.springframework.integration.support.locks.DistributedLock;
-import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.stereotype.Service;
 
 import java.time.Clock;
@@ -24,14 +24,20 @@ import java.util.concurrent.atomic.AtomicReference;
 @Service
 @RequiredArgsConstructor
 public class ElectorService implements SmartLifecycle {
+    // Upper bound on how long stop() waits for the scheduler thread to release the lock (see
+    // awaitLockRelease). Comfortably inside a pod's terminationGracePeriodSeconds.
+    private static final Duration RELEASE_TIMEOUT = Duration.ofSeconds(5);
+
     @Nonnull
     private final LockCallbacks callbacks;
     @Nonnull
     private final ElectorProperties electorProperties;
     @Nonnull
     private final RedisLockRegistry lockRegistry;
+    // Concrete type (not the TaskScheduler interface) because stop() needs submit()'s Future to
+    // wait for the shutdown-time lock release; see awaitLockRelease.
     @Nonnull
-    private final TaskScheduler taskScheduler;
+    private final ThreadPoolTaskScheduler taskScheduler;
     @Nonnull
     private final HealthProbe healthProbe;
     @Nonnull
@@ -54,6 +60,9 @@ public class ElectorService implements SmartLifecycle {
         deadlockSince.set(null);
         consecutiveProbeFailures.set(0);
         log.info("Starting ElectorService");
+        // So a freshly (re)created pod carries the label from boot rather than staying unlabeled
+        // until it wins or loses its first election.
+        callbacks.ensureSelfLabeled();
         taskScheduler.schedule(this::lockLoop, clock.instant());
     }
 
@@ -62,7 +71,7 @@ public class ElectorService implements SmartLifecycle {
         log.info("Stopping ElectorService");
         running.set(false);
         cancelRefreshTask();
-        releaseLockIfHeld();
+        awaitLockRelease();
     }
 
     @Override
@@ -80,6 +89,27 @@ public class ElectorService implements SmartLifecycle {
         final ScheduledFuture<?> future = refreshFuture.getAndSet(null);
         if (future != null && !future.isCancelled()) {
             future.cancel(true);
+        }
+    }
+
+    // DistributedLock.unlock() is thread-owned (RedisLockRegistry.RedisLock wraps a local
+    // ReentrantLock and throws IllegalStateException if unlocked off-thread). Acquisition always
+    // happens on the taskScheduler thread (lockLoop/refreshLock), but SmartLifecycle#stop() runs on
+    // whatever thread Spring's context shutdown uses, so releasing directly here would always fail
+    // and leak the Redis key for the full lease TTL. Route the release through the scheduler thread
+    // instead and wait briefly for it to finish.
+    private void awaitLockRelease() {
+        try {
+            taskScheduler
+                    .submit(this::releaseLockIfHeld)
+                    .get(RELEASE_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (final InterruptedException e) {
+            Thread
+                    .currentThread()
+                    .interrupt();
+            log.warn("Interrupted while releasing lock during shutdown", e);
+        } catch (final Exception e) {
+            log.error("Failed to release lock during shutdown within {}", RELEASE_TIMEOUT, e);
         }
     }
 
@@ -271,15 +301,36 @@ public class ElectorService implements SmartLifecycle {
                 consecutiveProbeFailures.set(0);
             }
 
-            lockRegistry.renewLock(electorProperties.getLockName(), electorProperties.getLeaseDuration());
-            log.debug("Lock TTL extended by {} seconds",
-                      electorProperties
-                              .getLeaseDuration()
-                              .get(ChronoUnit.SECONDS));
+            renewLockWithRetry();
+            // Self-heals any label a prior attempt failed to set (slow API server, a pod created
+            // after the last election) instead of leaving it wrong until the next leadership change.
+            callbacks.reconcileLeaderLabels();
         } catch (final Exception e) {
             log.error("Error while refreshing lock, treating as lock lost", e);
             handleLockLost();
         }
+    }
+
+    // A single transient Redis blip should not cost leadership outright: renewDeadline (60s
+    // default) leaves ample slack before the lease (120s default) actually expires, so one
+    // immediate retry absorbs a blip that would otherwise trigger a full re-election.
+    private void renewLockWithRetry() {
+        try {
+            renewLockOnce();
+        } catch (final Exception first) {
+            log.warn("First attempt to renew lock '{}' failed, retrying once immediately",
+                     electorProperties.getLockName(),
+                     first);
+            renewLockOnce();
+        }
+    }
+
+    private void renewLockOnce() {
+        lockRegistry.renewLock(electorProperties.getLockName(), electorProperties.getLeaseDuration());
+        log.debug("Lock TTL extended by {} seconds",
+                  electorProperties
+                          .getLeaseDuration()
+                          .get(ChronoUnit.SECONDS));
     }
 
     private void handleLockLost() {

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorService.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorService.java
@@ -101,7 +101,7 @@ public class ElectorService implements SmartLifecycle {
     private void awaitLockRelease() {
         try {
             taskScheduler
-                    .submit(this::releaseLockIfHeld)
+                    .submit(this::releaseLockAndClearLabelIfHeld)
                     .get(RELEASE_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
         } catch (final InterruptedException e) {
             Thread
@@ -113,9 +113,19 @@ public class ElectorService implements SmartLifecycle {
         }
     }
 
+    // Runs on the scheduler thread (see awaitLockRelease). Only a pod that was actually leading
+    // needs its label cleared here - a non-leader pod's label is already false.
+    private void releaseLockAndClearLabelIfHeld() {
+        if (releaseLockIfHeld()) {
+            callbacks.onShutdown();
+        }
+    }
+
     // --- Refresh logic: interval is configurable via electorProperties.getRenewDeadline() ---
 
-    private void releaseLockIfHeld() {
+    // Returns whether this pod was holding the lock (i.e. was leader), regardless of whether the
+    // unlock call itself succeeded.
+    private boolean releaseLockIfHeld() {
         final DistributedLock currentLock = lock.getAndSet(null);
         if (currentLock != null) {
             try {
@@ -124,7 +134,9 @@ public class ElectorService implements SmartLifecycle {
             } catch (final Exception e) {
                 log.error("Error while releasing lock", e);
             }
+            return true;
         }
+        return false;
     }
 
     private void lockLoop() {

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorService.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorService.java
@@ -229,7 +229,7 @@ public class ElectorService implements SmartLifecycle {
         lock.set(newLock);
         log.info("Lock '{}' acquired", electorProperties.getLockName());
         try {
-            callbacks.onLockAcquired();
+            callbacks.onLockAcquired(this::stillOwnsLock);
         } catch (final Exception e) {
             log.error("Lock acquired, but post-acquire callback failed; releasing lock and retrying in {}",
                       electorProperties.getRetryPeriod(),
@@ -316,7 +316,9 @@ public class ElectorService implements SmartLifecycle {
             renewLockWithRetry();
             // Self-heals any label a prior attempt failed to set (slow API server, a pod created
             // after the last election) instead of leaving it wrong until the next leadership change.
-            callbacks.reconcileLeaderLabels();
+            // Passes stillOwnsLock so a reconcile that outlives the lease stops before stamping stale
+            // labels once another pod has taken over.
+            callbacks.reconcileLeaderLabels(this::stillOwnsLock);
         } catch (final Exception e) {
             log.error("Error while refreshing lock, treating as lock lost", e);
             handleLockLost();
@@ -343,6 +345,28 @@ public class ElectorService implements SmartLifecycle {
                   electorProperties
                           .getLeaseDuration()
                           .get(ChronoUnit.SECONDS));
+    }
+
+    // Re-confirms this pod still holds the Redis lock, and refreshes its lease as a side effect.
+    // Passed into LockCallbacks#reconcileLeaderLabels so a long-running label reconcile stops the
+    // moment ownership is lost instead of stamping stale labels. renewLock's Lua script only extends
+    // the key while Redis still maps it to THIS registry's client id, so a thrown/false result is a
+    // genuine "no longer the owner" signal (a lapsed lease another pod already took), not just local
+    // state — a purely local check can't see a Redis-side takeover. Runs on the scheduler thread, the
+    // same thread as the reconcile that calls it.
+    boolean stillOwnsLock() {
+        if (lock.get() == null) {
+            return false;
+        }
+        try {
+            lockRegistry.renewLock(electorProperties.getLockName(), electorProperties.getLeaseDuration());
+            return true;
+        } catch (final Exception e) {
+            log.warn("Could not confirm Redis ownership of lock '{}' mid-reconcile; treating as lost",
+                     electorProperties.getLockName(),
+                     e);
+            return false;
+        }
     }
 
     private void handleLockLost() {

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/LockCallbacks.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/LockCallbacks.java
@@ -68,7 +68,7 @@ public class LockCallbacks {
             }
 
             if (updated > 0 || failures > 0) {
-                log.info("Reconciled leader labels: {} updated, {} failed ({} pods total, leader={})",
+                log.info("Reconciled leader labels: {} updated, {} failed ({} pods total, leaderPod={})",
                          updated,
                          failures,
                          pods.size(),
@@ -129,6 +129,16 @@ public class LockCallbacks {
 
     public void onLockLost() {
         log.warn("Lock lost - removing leader label from self");
+        updatePodLeaderLabel(kubernetesClient.getNamespace(), selfPodName, false);
+    }
+
+    // Called on graceful shutdown, but only for a pod that was actually leading (see
+    // ElectorService#releaseLockAndClearLabelIfHeld) — otherwise the label is already false. Without
+    // this, a departing leader would stay labeled true for the rest of its terminationGracePeriod,
+    // which anything selecting directly on the label (not just the Service, which drops NotReady
+    // endpoints immediately) could still match.
+    public void onShutdown() {
+        log.info("Shutting down while leading - removing leader label from self");
         updatePodLeaderLabel(kubernetesClient.getNamespace(), selfPodName, false);
     }
 }

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/LockCallbacks.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/LockCallbacks.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
 
 @Slf4j
 @Component
@@ -27,9 +28,9 @@ public class LockCallbacks {
     @Value("${POD_NAME:unknown}")
     private String selfPodName;
 
-    public void onLockAcquired() {
+    public void onLockAcquired(final BooleanSupplier stillLeader) {
         log.info("Lock acquired - reconciling leader labels across deployment");
-        reconcileLeaderLabels();
+        reconcileLeaderLabels(stillLeader);
     }
 
     // Brings every pod's leader label in line with the current election result: true on self,
@@ -39,7 +40,13 @@ public class LockCallbacks {
     // election) instead of leaving it wrong until the next leadership change. Never throws: a
     // labeling problem is a side effect of leadership, not a reason to give it up, and the next
     // renewal tick (at most renewDeadline away) retries automatically.
-    public void reconcileLeaderLabels() {
+    //
+    // stillLeader re-confirms leadership (Redis-side; see ElectorService#stillOwnsLock) immediately
+    // before mutating each drifted pod. A reconcile that outlives the lease — a very slow API server
+    // or many drifted pods — must not keep stamping this pod's stale identity after another pod has
+    // taken over the lock, which would flip the new leader's label back to false and leave the
+    // deployment momentarily leaderless until the new leader's next reconcile.
+    public void reconcileLeaderLabels(final BooleanSupplier stillLeader) {
         final String namespace = kubernetesClient.getNamespace();
         try {
             final List<Pod> pods = kubernetesClient
@@ -59,6 +66,11 @@ public class LockCallbacks {
 
                 if (!needsLabelUpdate(pod, isLeader)) {
                     continue;
+                }
+                if (!stillLeader.getAsBoolean()) {
+                    log.warn("Halting leader-label reconcile: leadership no longer confirmed " +
+                             "(was leaderPod={}, {} pods updated before ownership was lost)", selfPodName, updated);
+                    return;
                 }
                 if (updatePodLeaderLabel(namespace, podName, isLeader)) {
                     updated++;

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/LockCallbacks.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/LockCallbacks.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Component
@@ -27,11 +28,20 @@ public class LockCallbacks {
     private String selfPodName;
 
     public void onLockAcquired() {
-        log.info("Lock acquired - updating leader labels across deployment");
-        final String namespace = kubernetesClient.getNamespace();
+        log.info("Lock acquired - reconciling leader labels across deployment");
+        reconcileLeaderLabels();
+    }
 
+    // Brings every pod's leader label in line with the current election result: true on self,
+    // false on everyone else. Idempotent (skips pods whose label already matches) and safe to call
+    // repeatedly, so ElectorService also calls this on every successful lock renewal — that self-
+    // heals a label a prior attempt failed to set (a slow API server, a pod created after the last
+    // election) instead of leaving it wrong until the next leadership change. Never throws: a
+    // labeling problem is a side effect of leadership, not a reason to give it up, and the next
+    // renewal tick (at most renewDeadline away) retries automatically.
+    public void reconcileLeaderLabels() {
+        final String namespace = kubernetesClient.getNamespace();
         try {
-            // Get all pods in the deployment
             final List<Pod> pods = kubernetesClient
                     .pods()
                     .inNamespace(namespace)
@@ -39,44 +49,44 @@ public class LockCallbacks {
                     .list()
                     .getItems();
 
-            int nonLeaderUpdateFailures = 0;
-
-            // Update all pods: set leader=true on self, leader=false on others
+            int updated = 0;
+            int failures = 0;
             for (final Pod pod : pods) {
                 final String podName = pod
                         .getMetadata()
                         .getName();
                 final boolean isLeader = podName.equals(selfPodName);
 
-                if (isLeader) {
-                    try {
-                        patchPodLeaderLabel(namespace, podName, true);
-                    } catch (final KubernetesClientException e) {
-                        final String message = "Failed to update leader label on elected pod " + selfPodName;
-                        log.error(message, e);
-                        throw new IllegalStateException(message, e);
-                    }
-                } else if (!updateNonLeaderPodLabel(namespace, podName)) {
-                    nonLeaderUpdateFailures++;
+                if (!needsLabelUpdate(pod, isLeader)) {
+                    continue;
+                }
+                if (updatePodLeaderLabel(namespace, podName, isLeader)) {
+                    updated++;
+                } else {
+                    failures++;
                 }
             }
 
-            final int nonLeaderPods = pods.size() - 1;
-            if (nonLeaderUpdateFailures == 0) {
-                log.info("Successfully updated leader labels: {} is leader, {} other pods marked as non-leader",
-                         selfPodName,
-                         nonLeaderPods);
-            } else {
-                log.warn("Updated leader label on {}, but failed to mark {} of {} other pods as non-leader",
-                         selfPodName,
-                         nonLeaderUpdateFailures,
-                         nonLeaderPods);
+            if (updated > 0 || failures > 0) {
+                log.info("Reconciled leader labels: {} updated, {} failed ({} pods total, leader={})",
+                         updated,
+                         failures,
+                         pods.size(),
+                         selfPodName);
             }
         } catch (final KubernetesClientException e) {
-            final String message = "Failed to update leader labels on lock acquisition";
-            log.error(message, e);
-            throw new IllegalStateException(message, e);
+            log.error("Failed to list pods while reconciling leader labels; will retry on next reconcile", e);
         }
+    }
+
+    private boolean needsLabelUpdate(final Pod pod, final boolean isLeader) {
+        final Map<String, String> labels = pod
+                .getMetadata()
+                .getLabels();
+        final String current = labels == null ? null : labels.get(electorProperties.getLabelKey());
+        return !Boolean
+                .toString(isLeader)
+                .equals(current);
     }
 
     private void patchPodLeaderLabel(final String namespace, final String podName, final boolean isLeader) {
@@ -94,19 +104,31 @@ public class LockCallbacks {
         log.debug("Set {}={} on pod {}", electorProperties.getLabelKey(), isLeader, podName);
     }
 
-    private boolean updateNonLeaderPodLabel(final String namespace, final String podName) {
+    private boolean updatePodLeaderLabel(final String namespace, final String podName, final boolean isLeader) {
         try {
-            patchPodLeaderLabel(namespace, podName, false);
+            patchPodLeaderLabel(namespace, podName, isLeader);
             return true;
         } catch (final KubernetesClientException e) {
-            log.warn("Failed to update leader label on pod {}", podName, e);
+            if (isLeader) {
+                log.error("Failed to update leader label on elected pod {}; will retry on next reconcile",
+                          podName,
+                          e);
+            } else {
+                log.warn("Failed to update leader label on pod {}", podName, e);
+            }
             return false;
         }
     }
 
+    // Called once on startup so a freshly (re)created pod always carries the label from boot
+    // instead of staying unlabeled until it wins (or loses) its first election.
+    public void ensureSelfLabeled() {
+        log.info("Initializing leader label on self at startup");
+        updatePodLeaderLabel(kubernetesClient.getNamespace(), selfPodName, false);
+    }
+
     public void onLockLost() {
         log.warn("Lock lost - removing leader label from self");
-        final String namespace = kubernetesClient.getNamespace();
-        updateNonLeaderPodLabel(namespace, selfPodName);
+        updatePodLeaderLabel(kubernetesClient.getNamespace(), selfPodName, false);
     }
 }

--- a/src/test/java/io/jaredbrown/k8s/leader/configuration/TaskSchedulerConfigurationTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/configuration/TaskSchedulerConfigurationTest.java
@@ -1,0 +1,25 @@
+package io.jaredbrown.k8s.leader.configuration;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TaskSchedulerConfigurationTest {
+
+    @Test
+    void taskScheduler_shouldBeSingleThreadedAndAcceptTasksAfterContextClose() {
+        final ThreadPoolTaskScheduler scheduler = new TaskSchedulerConfiguration().taskScheduler();
+
+        // getPoolSize() reflects the live executor's current thread count (0 until a task actually
+        // runs) once initialized, not the configured value - so read the configured field directly.
+        assertEquals(1, (int) ReflectionTestUtils.getField(scheduler, "poolSize"));
+        // Regression guard: without this flag, ExecutorConfigurationSupport shuts the executor down
+        // on ContextClosedEvent - which fires before any SmartLifecycle#stop() runs - so
+        // ElectorService#awaitLockRelease's submit() would always throw TaskRejectedException and
+        // the Redis lock would leak on every graceful shutdown.
+        assertTrue((boolean) ReflectionTestUtils.getField(scheduler, "acceptTasksAfterContextClose"));
+    }
+}

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorServiceTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.integration.redis.util.RedisLockRegistry;
 import org.springframework.integration.support.locks.DistributedLock;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -18,6 +19,7 @@ import java.time.ZoneOffset;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -151,7 +153,7 @@ class ElectorServiceTest {
         // Then
         verify(lockRegistry).obtain("test-lock");
         verify(lock).tryLock(5L, TimeUnit.SECONDS);
-        verify(callbacks).onLockAcquired();
+        verify(callbacks).onLockAcquired(any());
         verify(taskScheduler).scheduleAtFixedRate(any(Runnable.class), any(Instant.class), eq(Duration.ofSeconds(60)));
     }
 
@@ -162,7 +164,7 @@ class ElectorServiceTest {
         when(lock.tryLock(5L, TimeUnit.SECONDS)).thenReturn(true);
         doThrow(new IllegalStateException("failed to label elected pod"))
                 .when(callbacks)
-                .onLockAcquired();
+                .onLockAcquired(any());
 
         electorService.start();
 
@@ -175,7 +177,7 @@ class ElectorServiceTest {
                 .run();
 
         // Then
-        verify(callbacks).onLockAcquired();
+        verify(callbacks).onLockAcquired(any());
         verify(lock).unlock();
         verify(taskScheduler, never()).scheduleAtFixedRate(any(Runnable.class), any(Instant.class), any(Duration.class));
         verify(taskScheduler, times(2)).schedule(any(Runnable.class), any(Instant.class));
@@ -201,7 +203,7 @@ class ElectorServiceTest {
         // Then
         verify(lockRegistry).obtain("test-lock");
         verify(lock).tryLock(5L, TimeUnit.SECONDS);
-        verify(callbacks, never()).onLockAcquired();
+        verify(callbacks, never()).onLockAcquired(any());
         // Should schedule retry
         verify(taskScheduler, times(2)).schedule(any(Runnable.class), any(Instant.class));
     }
@@ -224,7 +226,7 @@ class ElectorServiceTest {
                 .run();
 
         // Then
-        verify(callbacks, never()).onLockAcquired();
+        verify(callbacks, never()).onLockAcquired(any());
         assertTrue(Thread.interrupted()); // Verify interrupt flag is set
     }
 
@@ -246,7 +248,7 @@ class ElectorServiceTest {
                 .run();
 
         // Then
-        verify(callbacks, never()).onLockAcquired();
+        verify(callbacks, never()).onLockAcquired(any());
         // Should schedule retry
         verify(taskScheduler, times(2)).schedule(any(Runnable.class), any(Instant.class));
     }
@@ -282,7 +284,7 @@ class ElectorServiceTest {
         // Then
         verify(lockRegistry).renewLock("test-lock", Duration.ofSeconds(120));
         // Self-heals any label a prior attempt failed to set, every renewal tick.
-        verify(callbacks).reconcileLeaderLabels();
+        verify(callbacks).reconcileLeaderLabels(any());
     }
 
     @Test
@@ -318,7 +320,7 @@ class ElectorServiceTest {
         // Then: a single transient failure does not cost leadership — it's absorbed by the retry.
         verify(lockRegistry, times(2)).renewLock("test-lock", Duration.ofSeconds(120));
         verify(callbacks, never()).onLockLost();
-        verify(callbacks).reconcileLeaderLabels();
+        verify(callbacks).reconcileLeaderLabels(any());
     }
 
     @Test
@@ -393,7 +395,7 @@ class ElectorServiceTest {
         // Then: it does not lead, releases the transiently-held lock, and re-probes — but on the
         // longer unhealthy backoff (30s), NOT the tight retryPeriod (5s). Re-grabbing the free lock
         // every retryPeriod is exactly the livelock that starves the healthy peers racing for it.
-        verify(callbacks, never()).onLockAcquired();
+        verify(callbacks, never()).onLockAcquired(any());
         verify(lock).unlock();
         verify(taskScheduler, never()).scheduleAtFixedRate(any(Runnable.class), any(Instant.class), any(Duration.class));
         final ArgumentCaptor<Instant> whenCaptor = ArgumentCaptor.forClass(Instant.class);
@@ -429,7 +431,7 @@ class ElectorServiceTest {
                 .run();
 
         // Then: it re-probes on retryPeriod (5s), not the unhealthy backoff (30s).
-        verify(callbacks, never()).onLockAcquired();
+        verify(callbacks, never()).onLockAcquired(any());
         verify(lock).unlock();
         final ArgumentCaptor<Instant> whenCaptor = ArgumentCaptor.forClass(Instant.class);
         verify(taskScheduler, times(2)).schedule(any(Runnable.class), whenCaptor.capture());
@@ -457,7 +459,7 @@ class ElectorServiceTest {
 
         // Then: an unhealthy pod has no business racing for leadership, so it re-probes on the
         // longer backoff (30s) rather than the retryPeriod (5s) a healthy pod would use here.
-        verify(callbacks, never()).onLockAcquired();
+        verify(callbacks, never()).onLockAcquired(any());
         final ArgumentCaptor<Instant> whenCaptor = ArgumentCaptor.forClass(Instant.class);
         verify(taskScheduler, times(2)).schedule(any(Runnable.class), whenCaptor.capture());
         final Instant t0 = Instant.parse("2026-01-01T00:00:00Z");
@@ -513,7 +515,7 @@ class ElectorServiceTest {
                 .run();
 
         // Then: it leads (degraded) rather than deadlocking forever
-        verify(callbacks).onLockAcquired();
+        verify(callbacks).onLockAcquired(any());
         verify(taskScheduler).scheduleAtFixedRate(any(Runnable.class), any(Instant.class), eq(Duration.ofSeconds(60)));
     }
 
@@ -580,7 +582,7 @@ class ElectorServiceTest {
         // Then: a single failure below the threshold keeps the lock (renews, does not relinquish)
         verify(lockRegistry).renewLock("test-lock", Duration.ofSeconds(120));
         verify(callbacks, never()).onLockLost();
-        verify(callbacks).reconcileLeaderLabels();
+        verify(callbacks).reconcileLeaderLabels(any());
     }
 
     @Test
@@ -606,12 +608,12 @@ class ElectorServiceTest {
 
         // 1) First loop, still within grace: starts the deadlock timer but does not lead.
         lockLoop.run();
-        verify(callbacks, never()).onLockAcquired();
+        verify(callbacks, never()).onLockAcquired(any());
 
         // 2) Grace elapses → next loop breaks the deadlock and leads (degraded).
         clock.advance(Duration.ofMinutes(6));
         lockLoop.run();
-        verify(callbacks, times(1)).onLockAcquired();
+        verify(callbacks, times(1)).onLockAcquired(any());
 
         // Fire the refresh: unhealthy at threshold 1 → relinquish leadership.
         final ArgumentCaptor<Runnable> refreshCaptor = ArgumentCaptor.forClass(Runnable.class);
@@ -624,7 +626,40 @@ class ElectorServiceTest {
         // 3) Immediate re-acquire attempt, still unhealthy, no time advanced: must NOT re-lead,
         //    proving the deadlock timer was reset on becoming leader (still only one acquisition).
         lockLoop.run();
-        verify(callbacks, times(1)).onLockAcquired();
+        verify(callbacks, times(1)).onLockAcquired(any());
+    }
+
+    @Test
+    void stillOwnsLock_shouldReturnFalseAndSkipRedisWhenNotLeader() {
+        // No lock held: definitely not leader, and no point issuing a Redis renew to confirm it.
+        assertFalse(electorService.stillOwnsLock());
+        verify(lockRegistry, never()).renewLock(anyString(), any(Duration.class));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void stillOwnsLock_shouldRenewAndReturnTrueWhenStillOwned() {
+        // Given: this pod currently holds the lock.
+        ((AtomicReference<DistributedLock>) ReflectionTestUtils.getField(electorService, "lock")).set(lock);
+
+        // When/Then: a successful renew confirms Redis still maps the key to this client, and refreshes
+        // the lease as a side effect.
+        assertTrue(electorService.stillOwnsLock());
+        verify(lockRegistry).renewLock("test-lock", Duration.ofSeconds(120));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void stillOwnsLock_shouldReturnFalseWhenRenewRejected() {
+        // Given: this pod thinks it holds the lock, but Redis has already handed it to another pod, so
+        // renewLock's Lua script fails to match this client id and the registry throws.
+        ((AtomicReference<DistributedLock>) ReflectionTestUtils.getField(electorService, "lock")).set(lock);
+        doThrow(new IllegalStateException("Could not renew mutex at test-lock"))
+                .when(lockRegistry)
+                .renewLock(anyString(), any(Duration.class));
+
+        // When/Then: treated as ownership lost, so a mid-flight reconcile will stop stamping labels.
+        assertFalse(electorService.stillOwnsLock());
     }
 
     @Test

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorServiceTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorServiceTest.java
@@ -8,13 +8,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.integration.redis.util.RedisLockRegistry;
 import org.springframework.integration.support.locks.DistributedLock;
-import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -45,7 +46,7 @@ class ElectorServiceTest {
     private RedisLockRegistry lockRegistry;
 
     @Mock
-    private TaskScheduler taskScheduler;
+    private ThreadPoolTaskScheduler taskScheduler;
 
     @Mock
     private DistributedLock lock;
@@ -87,6 +88,19 @@ class ElectorServiceTest {
         lenient()
                 .when(electorProperties.getHealthProbeUnhealthyBackoff())
                 .thenReturn(Duration.ofSeconds(30));
+
+        // stop()/awaitLockRelease() submits the release onto taskScheduler and waits for it (the
+        // real ThreadPoolTaskScheduler runs it there); the mock doesn't run anything by default, so
+        // stub submit() to invoke the given task synchronously, matching real behavior closely
+        // enough for these tests.
+        lenient()
+                .when(taskScheduler.submit(any(Runnable.class)))
+                .thenAnswer(invocation -> {
+                    invocation
+                            .<Runnable>getArgument(0)
+                            .run();
+                    return CompletableFuture.completedFuture(null);
+                });
     }
 
     @Test
@@ -97,6 +111,8 @@ class ElectorServiceTest {
         // Then
         assertTrue(electorService.isRunning());
         verify(taskScheduler).schedule(any(Runnable.class), any(Instant.class));
+        // Every pod carries the label from boot, before it has contested any election.
+        verify(callbacks).ensureSelfLabeled();
     }
 
     @Test
@@ -265,12 +281,50 @@ class ElectorServiceTest {
 
         // Then
         verify(lockRegistry).renewLock("test-lock", Duration.ofSeconds(120));
+        // Self-heals any label a prior attempt failed to set, every renewal tick.
+        verify(callbacks).reconcileLeaderLabels();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void refreshLock_shouldRetryOnceThenSucceedOnTransientRenewFailure() throws Exception {
+        // Given: the first renew attempt throws, the second (immediate retry) succeeds.
+        when(lockRegistry.obtain("test-lock")).thenReturn(lock);
+        when(lock.tryLock(5L, TimeUnit.SECONDS)).thenReturn(true);
+        when(taskScheduler.scheduleAtFixedRate(any(Runnable.class),
+                                               any(Instant.class),
+                                               any(Duration.class))).thenReturn((ScheduledFuture) scheduledFuture);
+        doThrow(new RuntimeException("Redis blip"))
+                .doNothing()
+                .when(lockRegistry)
+                .renewLock(anyString(), any(Duration.class));
+
+        electorService.start();
+
+        final ArgumentCaptor<Runnable> lockLoopCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler).schedule(lockLoopCaptor.capture(), any(Instant.class));
+        lockLoopCaptor
+                .getValue()
+                .run();
+
+        final ArgumentCaptor<Runnable> refreshCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler).scheduleAtFixedRate(refreshCaptor.capture(), any(Instant.class), any(Duration.class));
+
+        // When
+        refreshCaptor
+                .getValue()
+                .run();
+
+        // Then: a single transient failure does not cost leadership — it's absorbed by the retry.
+        verify(lockRegistry, times(2)).renewLock("test-lock", Duration.ofSeconds(120));
+        verify(callbacks, never()).onLockLost();
+        verify(callbacks).reconcileLeaderLabels();
     }
 
     @Test
     @SuppressWarnings("unchecked")
     void refreshLock_shouldHandleLockLostOnRenewFailure() throws Exception {
-        // Given
+        // Given: both the initial renew attempt AND its immediate retry fail.
         when(lockRegistry.obtain("test-lock")).thenReturn(lock);
         when(lock.tryLock(5L, TimeUnit.SECONDS)).thenReturn(true);
         when(taskScheduler.scheduleAtFixedRate(any(Runnable.class),
@@ -298,7 +352,8 @@ class ElectorServiceTest {
                 .getValue()
                 .run();
 
-        // Then
+        // Then: the retry was attempted (two calls total) before giving up leadership.
+        verify(lockRegistry, times(2)).renewLock("test-lock", Duration.ofSeconds(120));
         verify(callbacks).onLockLost();
         verify(scheduledFuture).cancel(true);
         verify(lock).unlock();
@@ -525,6 +580,7 @@ class ElectorServiceTest {
         // Then: a single failure below the threshold keeps the lock (renews, does not relinquish)
         verify(lockRegistry).renewLock("test-lock", Duration.ofSeconds(120));
         verify(callbacks, never()).onLockLost();
+        verify(callbacks).reconcileLeaderLabels();
     }
 
     @Test
@@ -616,6 +672,47 @@ class ElectorServiceTest {
 
         // Then - should handle exception gracefully
         verify(lock).unlock();
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void stop_shouldReleaseLockViaSchedulerThreadNotCallingThread() throws Exception {
+        // DistributedLock.unlock() is thread-owned (RedisLockRegistry.RedisLock wraps a local
+        // ReentrantLock); calling it directly from stop()'s caller thread would throw
+        // IllegalStateException against a real lock. stop() must route the release through the
+        // taskScheduler instead of calling releaseLockIfHeld() inline.
+        when(lockRegistry.obtain("test-lock")).thenReturn(lock);
+        when(lock.tryLock(5L, TimeUnit.SECONDS)).thenReturn(true);
+        when(taskScheduler.scheduleAtFixedRate(any(Runnable.class),
+                                               any(Instant.class),
+                                               any(Duration.class))).thenReturn((ScheduledFuture) scheduledFuture);
+
+        electorService.start();
+        final ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler).schedule(runnableCaptor.capture(), any(Instant.class));
+        runnableCaptor
+                .getValue()
+                .run();
+
+        // When
+        electorService.stop();
+
+        // Then
+        verify(taskScheduler).submit(any(Runnable.class));
+        verify(lock).unlock();
+    }
+
+    @Test
+    void stop_shouldNotThrowWhenReleaseTimesOut() {
+        // Given: the scheduler never runs the submitted release task (simulating a wedged/backed-up
+        // scheduler thread) — submit() returns a Future that never completes.
+        when(taskScheduler.submit(any(Runnable.class))).thenReturn(new CompletableFuture<>());
+
+        // When/Then: stop() must not throw or hang the caller past the bounded wait.
+        electorService.start();
+        electorService.stop();
+
+        assertFalse(electorService.isRunning());
     }
 
     // A hand-advanceable clock so deadlock-grace timing can be tested deterministically.

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorServiceTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorServiceTest.java
@@ -643,6 +643,8 @@ class ElectorServiceTest {
 
         // Then - should not throw exception
         verify(lock, never()).unlock();
+        // Never held the lock (never led), so there's no self-label to clear.
+        verify(callbacks, never()).onShutdown();
     }
 
     @Test
@@ -670,8 +672,10 @@ class ElectorServiceTest {
         // When
         electorService.stop();
 
-        // Then - should handle exception gracefully
+        // Then - should handle exception gracefully, and still clear the self-label since this pod
+        // was leading regardless of whether the underlying unlock call itself succeeded.
         verify(lock).unlock();
+        verify(callbacks).onShutdown();
     }
 
     @Test
@@ -700,6 +704,9 @@ class ElectorServiceTest {
         // Then
         verify(taskScheduler).submit(any(Runnable.class));
         verify(lock).unlock();
+        // This pod was leading, so its self-label must be cleared rather than left true for the
+        // rest of terminationGracePeriodSeconds.
+        verify(callbacks).onShutdown();
     }
 
     @Test

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/LockCallbacksTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/LockCallbacksTest.java
@@ -18,8 +18,10 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -92,7 +94,7 @@ class LockCallbacksTest {
         when(namespacedPods.withName("pod-2")).thenReturn(followerPodResource);
 
         // When
-        lockCallbacks.onLockAcquired();
+        lockCallbacks.onLockAcquired(() -> true);
 
         // Then
         verify(namespacedPods).withLabel("app", APP_NAME);
@@ -131,7 +133,7 @@ class LockCallbacksTest {
         when(podList.getItems()).thenReturn(List.of(leaderPod, followerPod));
 
         // When
-        lockCallbacks.reconcileLeaderLabels();
+        lockCallbacks.reconcileLeaderLabels(() -> true);
 
         // Then: idempotent — no pod needed a patch, so none was attempted.
         verify(namespacedPods, never()).withName(any(String.class));
@@ -150,11 +152,79 @@ class LockCallbacksTest {
         when(namespacedPods.withName("pod-2")).thenReturn(peerPodResource);
 
         // When
-        lockCallbacks.reconcileLeaderLabels();
+        lockCallbacks.reconcileLeaderLabels(() -> true);
 
         // Then
         verify(namespacedPods, never()).withName(SELF_POD_NAME);
         verify(peerPodResource).patch(any(PatchContext.class), any(Pod.class));
+    }
+
+    @Test
+    void reconcileLeaderLabels_shouldNotPatchAnyPodWhenOwnershipAlreadyLost() {
+        // Given: two pods have drifted labels, but this pod has already lost leadership.
+        final Pod leaderPod = podWithLabel(SELF_POD_NAME, "false"); // drifted: should be true if leader
+        final Pod peerPod = podWithLabel("pod-2", "true");          // drifted: should be false
+
+        when(namespacedPods.withLabel("app", APP_NAME)).thenReturn(labeledPods);
+        when(labeledPods.list()).thenReturn(podList);
+        when(podList.getItems()).thenReturn(List.of(leaderPod, peerPod));
+
+        // When: the ownership recheck fails before the first mutation.
+        lockCallbacks.reconcileLeaderLabels(() -> false);
+
+        // Then: not a single pod was patched — no stamping stale labels after another pod took over.
+        verify(namespacedPods, never()).withName(any(String.class));
+    }
+
+    @Test
+    void reconcileLeaderLabels_shouldRecheckOwnershipBeforeEachDriftedPod() {
+        // Given: two drifted pods that both need a patch.
+        final PodResource leaderPodResource = mock(PodResource.class);
+        final PodResource peerPodResource = mock(PodResource.class);
+        final Pod leaderPod = podWithLabel(SELF_POD_NAME, "false");
+        final Pod peerPod = podWithLabel("pod-2", "true");
+
+        when(namespacedPods.withLabel("app", APP_NAME)).thenReturn(labeledPods);
+        when(labeledPods.list()).thenReturn(podList);
+        when(podList.getItems()).thenReturn(List.of(leaderPod, peerPod));
+        when(namespacedPods.withName(SELF_POD_NAME)).thenReturn(leaderPodResource);
+        when(namespacedPods.withName("pod-2")).thenReturn(peerPodResource);
+
+        final AtomicInteger checks = new AtomicInteger();
+
+        // When
+        lockCallbacks.reconcileLeaderLabels(() -> {
+            checks.incrementAndGet();
+            return true;
+        });
+
+        // Then: ownership was re-confirmed once per pod actually mutated, and both were patched.
+        assertEquals(2, checks.get());
+        verify(leaderPodResource).patch(any(PatchContext.class), any(Pod.class));
+        verify(peerPodResource).patch(any(PatchContext.class), any(Pod.class));
+    }
+
+    @Test
+    void reconcileLeaderLabels_shouldStopPatchingOnceOwnershipLostMidReconcile() {
+        // Given: first drifted pod is patched while still leader; ownership is lost before the second.
+        final PodResource leaderPodResource = mock(PodResource.class);
+        final Pod leaderPod = podWithLabel(SELF_POD_NAME, "false");
+        final Pod peerPod = podWithLabel("pod-2", "true");
+
+        when(namespacedPods.withLabel("app", APP_NAME)).thenReturn(labeledPods);
+        when(labeledPods.list()).thenReturn(podList);
+        when(podList.getItems()).thenReturn(List.of(leaderPod, peerPod));
+        when(namespacedPods.withName(SELF_POD_NAME)).thenReturn(leaderPodResource);
+
+        final Iterator<Boolean> ownership = List.of(true, false).iterator();
+
+        // When
+        lockCallbacks.reconcileLeaderLabels(ownership::next);
+
+        // Then: the first pod was patched, but the reconcile halted before touching the second — it
+        // never even resolved pod-2's resource.
+        verify(leaderPodResource).patch(any(PatchContext.class), any(Pod.class));
+        verify(namespacedPods, never()).withName("pod-2");
     }
 
     @Test
@@ -165,7 +235,7 @@ class LockCallbacksTest {
 
         // When/Then: a transient API failure must not cost leadership; the next renewal-tick
         // reconcile (ElectorService#refreshLock) retries automatically.
-        assertDoesNotThrow(() -> lockCallbacks.reconcileLeaderLabels());
+        assertDoesNotThrow(() -> lockCallbacks.reconcileLeaderLabels(() -> true));
     }
 
     @Test
@@ -193,7 +263,7 @@ class LockCallbacksTest {
                 .thenThrow(new KubernetesClientException("immutable spec update"));
 
         // When/Then: keep the lock; the next renewal-tick reconcile retries the self-label patch.
-        assertDoesNotThrow(() -> lockCallbacks.reconcileLeaderLabels());
+        assertDoesNotThrow(() -> lockCallbacks.reconcileLeaderLabels(() -> true));
         verify(leaderPodResource).patch(any(PatchContext.class), any(Pod.class));
     }
 

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/LockCallbacksTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/LockCallbacksTest.java
@@ -19,15 +19,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.List;
+import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -121,19 +121,51 @@ class LockCallbacksTest {
     }
 
     @Test
-    void onLockAcquired_shouldThrowWhenPodListQueryFails() {
+    void reconcileLeaderLabels_shouldSkipPodsWhoseLabelAlreadyMatches() {
+        // Given: both pods already carry the label value the election result implies.
+        final Pod leaderPod = podWithLabel(SELF_POD_NAME, "true");
+        final Pod followerPod = podWithLabel("pod-2", "false");
+
+        when(namespacedPods.withLabel("app", APP_NAME)).thenReturn(labeledPods);
+        when(labeledPods.list()).thenReturn(podList);
+        when(podList.getItems()).thenReturn(List.of(leaderPod, followerPod));
+
+        // When
+        lockCallbacks.reconcileLeaderLabels();
+
+        // Then: idempotent — no pod needed a patch, so none was attempted.
+        verify(namespacedPods, never()).withName(any(String.class));
+    }
+
+    @Test
+    void reconcileLeaderLabels_shouldPatchOnlyPodsThatDrifted() {
+        // Given: self already correctly labeled leader=true, peer stuck on a stale true.
+        final PodResource peerPodResource = mock(PodResource.class);
+        final Pod leaderPod = podWithLabel(SELF_POD_NAME, "true");
+        final Pod stalePeerPod = podWithLabel("pod-2", "true");
+
+        when(namespacedPods.withLabel("app", APP_NAME)).thenReturn(labeledPods);
+        when(labeledPods.list()).thenReturn(podList);
+        when(podList.getItems()).thenReturn(List.of(leaderPod, stalePeerPod));
+        when(namespacedPods.withName("pod-2")).thenReturn(peerPodResource);
+
+        // When
+        lockCallbacks.reconcileLeaderLabels();
+
+        // Then
+        verify(namespacedPods, never()).withName(SELF_POD_NAME);
+        verify(peerPodResource).patch(any(PatchContext.class), any(Pod.class));
+    }
+
+    @Test
+    void reconcileLeaderLabels_shouldNotThrowWhenPodListQueryFails() {
         // Given
         when(namespacedPods.withLabel("app", APP_NAME)).thenReturn(labeledPods);
         when(labeledPods.list()).thenThrow(new KubernetesClientException("Failed to list pods"));
 
-        // When/Then
-        final IllegalStateException exception = assertThrows(IllegalStateException.class,
-                                                             () -> lockCallbacks.onLockAcquired());
-
-        assertTrue(exception
-                           .getMessage()
-                           .contains("Failed to update leader labels"));
-        assertInstanceOf(KubernetesClientException.class, exception.getCause());
+        // When/Then: a transient API failure must not cost leadership; the next renewal-tick
+        // reconcile (ElectorService#refreshLock) retries automatically.
+        assertDoesNotThrow(() -> lockCallbacks.reconcileLeaderLabels());
     }
 
     @Test
@@ -150,7 +182,7 @@ class LockCallbacksTest {
     }
 
     @Test
-    void onLockAcquired_shouldThrowWhenLeaderPodLabelUpdateFails() {
+    void reconcileLeaderLabels_shouldNotThrowWhenLeaderPodLabelUpdateFails() {
         // Given
         final PodResource leaderPodResource = mock(PodResource.class);
         when(namespacedPods.withLabel("app", APP_NAME)).thenReturn(labeledPods);
@@ -160,21 +192,55 @@ class LockCallbacksTest {
         when(leaderPodResource.patch(any(PatchContext.class), any(Pod.class)))
                 .thenThrow(new KubernetesClientException("immutable spec update"));
 
-        // When/Then
-        final IllegalStateException exception = assertThrows(IllegalStateException.class,
-                                                             () -> lockCallbacks.onLockAcquired());
+        // When/Then: keep the lock; the next renewal-tick reconcile retries the self-label patch.
+        assertDoesNotThrow(() -> lockCallbacks.reconcileLeaderLabels());
+        verify(leaderPodResource).patch(any(PatchContext.class), any(Pod.class));
+    }
 
-        assertTrue(exception
-                           .getMessage()
-                           .contains("Failed to update leader label on elected pod"));
-        assertInstanceOf(KubernetesClientException.class, exception.getCause());
-        assertInstanceOf(KubernetesClientException.class, exception.getCause());
+    @Test
+    void ensureSelfLabeled_shouldSetSelfLabelToFalse() {
+        // Given
+        final PodResource selfPodResource = mock(PodResource.class);
+        when(namespacedPods.withName(SELF_POD_NAME)).thenReturn(selfPodResource);
+
+        // When
+        lockCallbacks.ensureSelfLabeled();
+
+        // Then: every pod carries the label from boot, before it has contested any election.
+        final ArgumentCaptor<Pod> patchCaptor = ArgumentCaptor.forClass(Pod.class);
+        verify(selfPodResource).patch(any(PatchContext.class), patchCaptor.capture());
+        assertEquals("false", patchCaptor
+                .getValue()
+                .getMetadata()
+                .getLabels()
+                .get(LABEL_KEY));
+    }
+
+    @Test
+    void ensureSelfLabeled_shouldNotThrowWhenPatchFails() {
+        // Given
+        final PodResource selfPodResource = mock(PodResource.class);
+        when(namespacedPods.withName(SELF_POD_NAME)).thenReturn(selfPodResource);
+        when(selfPodResource.patch(any(PatchContext.class), any(Pod.class)))
+                .thenThrow(new KubernetesClientException("API server unavailable"));
+
+        // When/Then
+        assertDoesNotThrow(() -> lockCallbacks.ensureSelfLabeled());
     }
 
     private static Pod pod(final String name) {
         return new PodBuilder()
                 .withNewMetadata()
                 .withName(name)
+                .endMetadata()
+                .build();
+    }
+
+    private static Pod podWithLabel(final String name, final String labelValue) {
+        return new PodBuilder()
+                .withNewMetadata()
+                .withName(name)
+                .withLabels(Map.of(LABEL_KEY, labelValue))
                 .endMetadata()
                 .build();
     }

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/LockCallbacksTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/LockCallbacksTest.java
@@ -228,6 +228,37 @@ class LockCallbacksTest {
         assertDoesNotThrow(() -> lockCallbacks.ensureSelfLabeled());
     }
 
+    @Test
+    void onShutdown_shouldSetSelfLabelToFalse() {
+        // Given
+        final PodResource selfPodResource = mock(PodResource.class);
+        when(namespacedPods.withName(SELF_POD_NAME)).thenReturn(selfPodResource);
+
+        // When
+        lockCallbacks.onShutdown();
+
+        // Then: a departing leader must not stay labeled true through its termination grace period.
+        final ArgumentCaptor<Pod> patchCaptor = ArgumentCaptor.forClass(Pod.class);
+        verify(selfPodResource).patch(any(PatchContext.class), patchCaptor.capture());
+        assertEquals("false", patchCaptor
+                .getValue()
+                .getMetadata()
+                .getLabels()
+                .get(LABEL_KEY));
+    }
+
+    @Test
+    void onShutdown_shouldNotThrowWhenPatchFails() {
+        // Given
+        final PodResource selfPodResource = mock(PodResource.class);
+        when(namespacedPods.withName(SELF_POD_NAME)).thenReturn(selfPodResource);
+        when(selfPodResource.patch(any(PatchContext.class), any(Pod.class)))
+                .thenThrow(new KubernetesClientException("API server unavailable"));
+
+        // When/Then
+        assertDoesNotThrow(() -> lockCallbacks.onShutdown());
+    }
+
     private static Pod pod(final String name) {
         return new PodBuilder()
                 .withNewMetadata()


### PR DESCRIPTION
## Summary

Root-caused an outage in homelab's pihole StatefulSet (`argocd/values/networking/dns/pihole.yaml`): pods were left with inconsistent/missing `pihole.jaredbrown.io/leader` labels — e.g. `pihole-0` had no label at all while `pihole-2` was `leader=true`. Two independent bugs in this elector caused it.

**Bug 1 — labeling was one-shot.** `LockCallbacks.onLockAcquired()` runs exactly once per acquisition. A transient patch failure (confirmed in the pihole-2 logs: a 10s PATCH timeout against `pihole-0` during a busy rolling update) was logged and dropped — nothing ever retried it. A pod created *after* the election (e.g. during a rollout) never gets labeled at all until the next leadership change.

**Bug 2 — `DistributedLock.unlock()` is thread-owned, but the scheduler wasn't.** `RedisLockRegistry.RedisLock#unlock()` throws `IllegalStateException` if called from a thread other than the one that acquired the lock (confirmed by reading the `spring-integration-redis` source). `TaskSchedulerConfiguration` used a 2-thread pool, so `lockLoop` (acquire) and `refreshLock` (renew/release) could land on different threads. Worse, `ElectorService.stop()` (invoked from Spring's shutdown thread, never the scheduler) called `unlock()` directly — this **always** fails on a real lock, leaking the Redis key for the full `leaseDuration` (120s default) on every graceful pod termination.

## Changes

- `LockCallbacks.reconcileLeaderLabels()`: idempotent (skips pods whose label already matches), never throws (a labeling problem no longer costs leadership — it's logged and retried on the next reconcile)
- `ElectorService.refreshLock()` now calls `reconcileLeaderLabels()` after every successful renew (not just on acquisition), so a missed/late-created pod self-heals within one `renewDeadline`
- `ElectorService.start()` calls a new `callbacks.ensureSelfLabeled()` (sets `leader=false`) before the first acquisition attempt, so a pod is never label-less from boot
- A failed lock renew is retried once immediately before being treated as lock-lost, absorbing a single transient Redis blip instead of forcing a full re-election
- `TaskSchedulerConfiguration` pinned to a single thread (was 2) — matches what `CLAUDE.md` already claimed ("single-threaded ScheduledExecutorService") but the code didn't actually do
- `ElectorService.stop()` now submits the release onto the scheduler thread and waits up to 5s, instead of calling `unlock()` directly from the Spring shutdown thread

## Test plan

- [x] `mvn clean install` — all 54 tests pass, jar builds
- [x] Added coverage: idempotent skip, patch-only-drifted pods, no-throw on list/patch failure, `ensureSelfLabeled`, renew-retry-then-succeed, renew-retry-then-fail (verifies 2 attempts), shutdown release routed through `taskScheduler.submit()` (not the calling thread), bounded shutdown wait doesn't hang when the scheduler is wedged
- [ ] After merge + Renovate bumps the `k8s-leader-elector` tag in homelab's `pihole.yaml`, confirm `kubectl get pods -n dns --show-labels` shows all 3 pods labeled and stays that way across a rollout

https://claude.ai/code/session_01G3BwSSy4W7HRxNqsuxUUs9