### PR TITLE
test: cover untested config beans and remaining branch gaps

### DIFF
--- a/src/test/java/io/jaredbrown/k8s/leader/configuration/K8sClientConfigurationTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/configuration/K8sClientConfigurationTest.java
@@ -1,0 +1,21 @@
+package io.jaredbrown.k8s.leader.configuration;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class K8sClientConfigurationTest {
+
+    @Test
+    void kubernetesClient_shouldBoundRequestTimeoutAndRetries() {
+        // fabric8 defaults to a 10s request timeout and up to 10 retries; every K8s call runs
+        // inline on ElectorService's single scheduler thread, so these must stay tightly bounded
+        // (see K8sClientConfiguration's class comment) or a slow API server could stall lock
+        // renewal past the lease or the shutdown-time release past its window.
+        try (KubernetesClient client = new K8sClientConfiguration().kubernetesClient()) {
+            assertEquals(2000, client.getConfiguration().getRequestTimeout());
+            assertEquals(1, client.getConfiguration().getRequestRetryBackoffLimit());
+        }
+    }
+}

--- a/src/test/java/io/jaredbrown/k8s/leader/configuration/RedisLockRegistryConfigurationTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/configuration/RedisLockRegistryConfigurationTest.java
@@ -1,0 +1,37 @@
+package io.jaredbrown.k8s.leader.configuration;
+
+import io.jaredbrown.k8s.leader.elector.ElectorProperties;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.integration.redis.util.RedisLockRegistry;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Duration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RedisLockRegistryConfigurationTest {
+
+    @Mock
+    private RedisConnectionFactory redisConnectionFactory;
+
+    @Mock
+    private ElectorProperties electorProperties;
+
+    @Test
+    void redisLockRegistry_shouldUseConfiguredLockNameAndLeaseDuration() {
+        when(electorProperties.getLockName()).thenReturn("test-lock");
+        when(electorProperties.getLeaseDuration()).thenReturn(Duration.ofSeconds(42));
+
+        final RedisLockRegistry registry =
+                new RedisLockRegistryConfiguration().redisLockRegistry(redisConnectionFactory, electorProperties);
+
+        assertEquals("test-lock-lock-registry", ReflectionTestUtils.getField(registry, "registryKey"));
+        assertEquals(Duration.ofSeconds(42), ReflectionTestUtils.getField(registry, "expireAfter"));
+    }
+}

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorServiceTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/ElectorServiceTest.java
@@ -17,6 +17,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -30,9 +31,11 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -755,6 +758,74 @@ class ElectorServiceTest {
         electorService.stop();
 
         assertFalse(electorService.isRunning());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void stop_shouldHandleInterruptedExceptionWhileAwaitingRelease() throws Exception {
+        // Given: the caller thread is interrupted while blocked on the release Future's get().
+        final Future<Object> releaseFuture = mock(Future.class);
+        when(taskScheduler.submit(any(Runnable.class))).thenReturn((Future) releaseFuture);
+        when(releaseFuture.get(anyLong(), any(TimeUnit.class))).thenThrow(new InterruptedException("Test interruption"));
+
+        // When/Then: stop() must not throw or propagate the exception, but must restore the
+        // interrupt flag it consumed rather than swallowing it silently.
+        electorService.start();
+        electorService.stop();
+
+        assertFalse(electorService.isRunning());
+        assertTrue(Thread.interrupted());
+    }
+
+    @Test
+    void lockLoop_shouldNoOpWhenServiceAlreadyStopped() {
+        // Given: a lockLoop tick was already queued on the scheduler before stop() ran (a normal
+        // race between the last scheduled retry and shutdown).
+        electorService.start();
+        final ArgumentCaptor<Runnable> runnableCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler).schedule(runnableCaptor.capture(), any(Instant.class));
+        electorService.stop();
+
+        // When: the already-queued tick fires anyway.
+        runnableCaptor
+                .getValue()
+                .run();
+
+        // Then: it returns immediately without attempting to acquire the lock.
+        verifyNoInteractions(lockRegistry);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void refreshLock_shouldTreatAsLockLostWhenServiceAlreadyStopped() throws Exception {
+        // Given: leadership acquired and a refresh tick already queued before stop() ran.
+        when(lockRegistry.obtain("test-lock")).thenReturn(lock);
+        when(lock.tryLock(5L, TimeUnit.SECONDS)).thenReturn(true);
+        when(taskScheduler.scheduleAtFixedRate(any(Runnable.class),
+                                               any(Instant.class),
+                                               any(Duration.class))).thenReturn((ScheduledFuture) scheduledFuture);
+
+        electorService.start();
+        final ArgumentCaptor<Runnable> lockLoopCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler).schedule(lockLoopCaptor.capture(), any(Instant.class));
+        lockLoopCaptor
+                .getValue()
+                .run();
+
+        final ArgumentCaptor<Runnable> refreshCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(taskScheduler).scheduleAtFixedRate(refreshCaptor.capture(), any(Instant.class), any(Duration.class));
+
+        electorService.stop();
+
+        // When: the already-queued refresh tick fires anyway.
+        refreshCaptor
+                .getValue()
+                .run();
+
+        // Then: treated as lock lost rather than attempting a renew against a stopped service, and
+        // no re-acquire is scheduled since running is false.
+        verify(lockRegistry, never()).renewLock(anyString(), any(Duration.class));
+        verify(callbacks).onLockLost();
     }
 
     // A hand-advanceable clock so deadlock-grace timing can be tested deterministically.

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/HealthProbeTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/HealthProbeTest.java
@@ -88,6 +88,17 @@ class HealthProbeTest {
     }
 
     @Test
+    void isHealthy_returnsFalseWhenReadThrows() throws IOException {
+        // A directory passes the isReadable() and freshness checks but Files.readString() throws
+        // IOException on it, exercising the catch block that reports unhealthy rather than
+        // propagating (e.g. the status file is deleted or replaced by a directory mid-read).
+        final Path directory = Files.createDirectory(tempDir.resolve("not-a-file"));
+        enabled(directory, Duration.ZERO);
+
+        assertFalse(new HealthProbe(electorProperties).isHealthy());
+    }
+
+    @Test
     void isHealthy_returnsFalseWhenPathUnset() {
         when(electorProperties.isHealthProbeEnabled()).thenReturn(true);
         lenient()

--- a/src/test/java/io/jaredbrown/k8s/leader/elector/LockCallbacksTest.java
+++ b/src/test/java/io/jaredbrown/k8s/leader/elector/LockCallbacksTest.java
@@ -248,6 +248,28 @@ class LockCallbacksTest {
     }
 
     @Test
+    void reconcileLeaderLabels_shouldTreatNullLabelsMapAsNeedingUpdate() {
+        // Given: a pod whose metadata carries no labels map at all (not merely missing the leader
+        // key) — e.g. a pod that predates the label selector requirement.
+        final PodResource podResource = mock(PodResource.class);
+        final Pod podWithNoLabels = pod("pod-2");
+        podWithNoLabels
+                .getMetadata()
+                .setLabels(null);
+
+        when(namespacedPods.withLabel("app", APP_NAME)).thenReturn(labeledPods);
+        when(labeledPods.list()).thenReturn(podList);
+        when(podList.getItems()).thenReturn(List.of(podWithNoLabels));
+        when(namespacedPods.withName("pod-2")).thenReturn(podResource);
+
+        // When
+        lockCallbacks.reconcileLeaderLabels(() -> true);
+
+        // Then: a null labels map is treated as drifted (current=null != "false") and gets patched.
+        verify(podResource).patch(any(PatchContext.class), any(Pod.class));
+    }
+
+    @Test
     void reconcileLeaderLabels_shouldNotThrowWhenPodListQueryFails() {
         // Given
         when(namespacedPods.withLabel("app", APP_NAME)).thenReturn(labeledPods);


### PR DESCRIPTION
## Summary
- Add tests for `RedisLockRegistryConfiguration` and `K8sClientConfiguration`, which had 0% coverage — the latter locks in the deliberate 2s timeout / 1 retry bound on Kubernetes API calls.
- Add tests for previously-untested branches: `ElectorService#awaitLockRelease`'s `InterruptedException` catch, the `running=false` early-return guards in `lockLoop`/`refreshLock` (a queued tick firing after `stop()`), `HealthProbe#isHealthy`'s `IOException` catch, and `LockCallbacks#needsLabelUpdate`'s null-labels-map branch.
- No production code changes — additive test coverage only.

## Test plan
- [x] `mvn test` — 79/79 passing (up from 72)
- [x] Verified via a temporary local JaCoCo run that all targeted gaps are now covered: both config classes 100%, `LockCallbacks` 100%, `ElectorService`/`HealthProbe` lines 100% (a few low-value short-circuit branch permutations on defensive null-checks remain uncovered — not in scope, noted for the author)

https://claude.ai/code/session_01PCFbnKspsNqfEDbet78LWw