### PR TITLE
fix(ci): authenticate release as GitHub App, not a long-lived PAT

### DIFF
--- a/.github/workflows/version-release.yml
+++ b/.github/workflows/version-release.yml
@@ -15,11 +15,35 @@ jobs:
     permissions:
       contents: write
     steps:
+    # Mint a short-lived (1h) installation token for the release GitHub App.
+    # semantic-release pushes the version-bump commit + tag AS this app, and
+    # main/beta's four rulesets (branch-integrity, require-pull-request,
+    # require-status-checks, require-up-to-date) each grant that app an
+    # `always` bypass, so its unsigned, unreviewed, unchecked release commit
+    # lands on the protected branch while contributors stay gated. APP_ID and
+    # APP_PRIVATE_KEY are synced into this repo's Actions secrets from OpenBao
+    # (secret/ci/release-app/app) by the homelab github-sync PushSecret, so the
+    # credential is rotated in one place and never pasted by hand.
+    #
+    # client-id, not app-id: create-github-app-token v3 deprecated app-id in
+    # favor of client-id. Both accept the same App ID / Client ID value and
+    # resolve identically internally, so APP_ID is the correct input here.
+    - name: Generate app token
+      id: app-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      with:
+        client-id: ${{ secrets.APP_ID }}
+        private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
     - name: Checkout repository
       uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         fetch-depth: 0
-        token: ${{ secrets.GH_TOKEN }}
+        # Persist the app token as the origin credential: the beta resync step
+        # below pushes with it. This is checkout's default, but the resync
+        # depends on it, so it is set explicitly rather than left implicit.
+        persist-credentials: true
+        token: ${{ steps.app-token.outputs.token }}
 
     # Captured as early as possible, before the slow steps below (npm ci,
     # semantic-release's own GitHub API calls) run, so the later
@@ -54,14 +78,14 @@ jobs:
     # release.yml workflow to build/push/sign the Docker image — decoupled
     # so an image-build failure can be retried (re-running failed jobs on
     # the tag push) without semantic-release re-evaluating whether there's
-    # anything new to release. Authenticated with GH_TOKEN (not the default
-    # GITHUB_TOKEN) because it carries this repo's release-automation bypass
-    # on the main/beta rulesets, needed to push the release commit + tag
-    # directly to the protected branch.
+    # anything new to release. Authenticated with the app token (not the
+    # default GITHUB_TOKEN) because the app carries this repo's
+    # release-automation bypass on the main/beta rulesets, needed to push the
+    # release commit + tag directly to the protected branch.
     - name: Run semantic-release
       id: release
       env:
-        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        GH_TOKEN: ${{ steps.app-token.outputs.token }}
       run: npx semantic-release
 
     # A squash merge of main -> beta does NOT make main's commits (or their
@@ -73,10 +97,11 @@ jobs:
     # in "Capture beta tip before release", at the start of this job - not
     # re-fetched here - so a beta merge landing anywhere during this job's
     # run (checkout, npm ci, the semantic-release run itself) aborts the
-    # push instead of being silently discarded. actions/checkout persisted
-    # secrets.GH_TOKEN as the origin credential above, so this push (to a
-    # different ref than was checked out) reuses it without needing to set
-    # it again here.
+    # push instead of being silently discarded. actions/checkout persisted the
+    # app token as the origin credential above, so this push (to a different
+    # ref than was checked out) reuses it without needing to set it again
+    # here - and the app's bypass covers refs/heads/beta too, which the
+    # ruleset protects alongside main.
     - name: Resync beta to main after a stable release
       if: steps.release.outputs.published == 'true' && github.ref_name == 'main'
       run: |


### PR DESCRIPTION
> **Depends on jabrown93/homelab#1916** — that PR pushes `APP_ID` / `APP_PRIVATE_KEY` into this repo's Actions secrets. Merge it (and let ESO sync) **before** this one.

## The PAT is already dead

`version-release.yml` used `secrets.GH_TOKEN`, a long-lived PAT, to push semantic-release's version-bump commit + tag to the protected `main`/`beta` branches.

**Every run since the automation landed in #88 has failed** at `Checkout repository`:

```
fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

The secret still resolves (masked in the log, so non-empty), but git gets a 401 and falls back to prompting. Consequences:

- `git log --all | grep -c "chore(release)"` → **0**
- `gh api /repos/jabrown93/k8s-leader-elector/releases --jq length` → **0**

This repo has never cut a release. The `v2.x` tags predate the automation. So this is the **fix for a broken pipeline**, not just hardening.

## The change

Mint a short-lived (1h) installation token, mirroring aura's release workflow:

```yaml
- name: Generate app token
  id: app-token
  uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
  with:
    client-id: ${{ secrets.APP_ID }}
    private-key: ${{ secrets.APP_PRIVATE_KEY }}
```

The credential now lives only in OpenBao (`secret/ci/release-app/app`) and reaches Actions via the homelab github-sync PushSecret — rotated in one place, and it can't silently expire the way a hand-pasted PAT does.

Details worth flagging:

- **`client-id`, not `app-id`** — create-github-app-token v3 deprecated `app-id`; both accept the same App ID value. aura hit this and fixed it in jabrown93/AURA#59; that run went green and published v1.7.2.
- **`persist-credentials: true` set explicitly** — already checkout's default, but the beta-resync step silently depends on it. Documented rather than implicit.
- **`permissions: contents: write` left alone.** Arguably vestigial now (the app token does every push; no step reads the default `GITHUB_TOKEN`), but tightening it in the same PR as the first-ever-working release is a bad trade. Follow-up.

## Why nothing else moved

| Piece | State |
|---|---|
| Rulesets grant release app (`3857914`) `always` bypass | already live on **all four** — byte-identical to aura |
| `gh-k8s-leader-elector` ESO SecretStore | already exists (added for the dockerhub push) |
| `k8s-leader-elector` in generator `DEFAULT_REPOS` | already there |

No Terraform change, no store regen, no drift-guard touch.

## Verification

Action pin `bcd2ba4` confirmed to resolve to exactly `v3.2.0` via the git ref API. YAML parses. No `secrets.GH_TOKEN` references remain.

Real proof is the first `main` push after both PRs land: expect a `chore(release):` commit authored by the app and a `v2.2.2`+ GitHub Release.

⚠️ **One unverified assumption:** that app `3857914` is *installed* on this repo. The ruleset lists it as a bypass actor, which strongly implies it, but confirming needs app-JWT auth a PAT can't do. If it isn't installed, the `Generate app token` step fails with "not installed" — a 30s check in the App's install settings.

## Cleanup after merge

The `GH_TOKEN` secret becomes orphaned (and is a dead PAT regardless):

```bash
gh secret delete GH_TOKEN --repo jabrown93/k8s-leader-elector
```

Separately, `DOCKERHUB_TOKEN` (last set 2025-12-20) and `FOSSA_API_KEY` are referenced by zero workflows — untouched here, but worth a look.