### PR TITLE
ci(codeql): migrate to jabrown93/ci/actions/codeql composite action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,12 +9,14 @@ on:
     - cron: '25 22 * * 5'
 jobs:
   analyze:
-    uses: jabrown93/.github/.github/workflows/codeql.yml@644b89511f2e5143fb600246050eaf3aa5f532eb # v1.5.0
-    with:
-      language: java-kotlin
-      build-mode: autobuild
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
       packages: read
       actions: read
       contents: read
+    steps:
+      - uses: jabrown93/ci/actions/codeql@63fdb1321ea7e94b330b23d87a9c9961ed6b86b5 # codeql-v1.0.0
+        with:
+          language: java-kotlin
+          build-mode: autobuild


### PR DESCRIPTION
**Phase 4 pilot** for the `jabrown93/.github` → `jabrown93/ci` reusable-CI migration.

Replaces the reusable-workflow call with the new composite action:

```diff
-    uses: jabrown93/.github/.github/workflows/codeql.yml@644b895 # v1.5.0
-    with: { language: java-kotlin, build-mode: autobuild }
+    runs-on: ubuntu-latest
     permissions: { security-events: write, packages: read, actions: read, contents: read }
+    steps:
+      - uses: jabrown93/ci/actions/codeql@63fdb13 # codeql-v1.0.0
+        with: { language: java-kotlin, build-mode: autobuild }
```

- Same `language`, `build-mode`, `permissions`, and SARIF category (`/language:java-kotlin`) — CodeQL results are unaffected.
- `runs-on` moves into this caller job (a composite action can't declare it).
- The job's **check name changes** (`analyze` instead of the nested reusable-workflow name), but this repo's only required status check is `test`, so merging isn't affected.

The CodeQL run on this PR validates the action end-to-end before the `homebridge` cutover. Renovate will also start proposing `codeql-v*` bumps via the per-component routing (jabrown93/.github#30 + #31).