### PR TITLE
docs: add Javadoc to all main-source classes and methods

### DIFF
--- a/src/main/java/io/jaredbrown/k8s/leader/Application.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/Application.java
@@ -4,10 +4,16 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
+/**
+ * Boots the leader-election sidecar's Spring context.
+ */
 @SpringBootApplication
 @ConfigurationPropertiesScan
 public class Application {
 
+    /**
+     * @param args standard Spring Boot command-line arguments
+     */
     public static void main(final String[] args) {
         SpringApplication.run(Application.class, args);
     }

--- a/src/main/java/io/jaredbrown/k8s/leader/configuration/K8sClientConfiguration.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/configuration/K8sClientConfiguration.java
@@ -7,22 +7,29 @@ import io.fabric8.kubernetes.client.KubernetesClientBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+/**
+ * Builds the {@link KubernetesClient} bean with tightened per-request bounds.
+ *
+ * <p>fabric8 defaults to a 10s per-request timeout and up to 10 retries
+ * ({@code Config.DEFAULT_REQUEST_TIMEOUT} / {@code DEFAULT_REQUEST_RETRY_BACKOFFLIMIT}).
+ * {@code ElectorService} drives every Kubernetes call inline on its single scheduler thread, so an
+ * unbounded call would (a) block the shutdown-time lock release past its 5s window
+ * ({@code RELEASE_TIMEOUT}) and (b) in the extreme, stall lock renewal past the lease while a label
+ * reconcile is in flight. Bounding both keeps a whole leader-label reconcile of a handful of pods
+ * comfortably inside the release window and the lease, so the scheduler thread stays responsive.
+ */
 @Configuration
 public class K8sClientConfiguration {
-    // fabric8 defaults to a 10s per-request timeout and up to 10 retries
-    // (Config.DEFAULT_REQUEST_TIMEOUT / DEFAULT_REQUEST_RETRY_BACKOFFLIMIT). ElectorService drives
-    // every Kubernetes call inline on its single scheduler thread, so an unbounded call would
-    // (a) block the shutdown-time lock release past its 5s window (RELEASE_TIMEOUT) and (b) in the
-    // extreme, stall lock renewal past the lease while a label reconcile is in flight. Bound both so a
-    // whole leader-label reconcile of a handful of pods finishes well inside the release window and
-    // the lease, keeping the scheduler thread responsive.
     private static final int REQUEST_TIMEOUT_MILLIS = 2000;
     private static final int REQUEST_RETRY_BACKOFF_LIMIT = 1;
 
+    /**
+     * @return a {@link KubernetesClient} built from the environment-derived config (in-cluster
+     * service-account token, API server, CA, namespace) with only the request-timeout and retry
+     * bounds overridden, so authentication is untouched
+     */
     @Bean(destroyMethod = "close")
     public KubernetesClient kubernetesClient() {
-        // Start from the environment-derived config (in-cluster service-account token, API server, CA,
-        // namespace) so auth is untouched, then override only the request bounds.
         final Config config = new ConfigBuilder(Config.autoConfigure(null))
                 .withRequestTimeout(REQUEST_TIMEOUT_MILLIS)
                 .withRequestRetryBackoffLimit(REQUEST_RETRY_BACKOFF_LIMIT)

--- a/src/main/java/io/jaredbrown/k8s/leader/configuration/RedisLockRegistryConfiguration.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/configuration/RedisLockRegistryConfiguration.java
@@ -7,8 +7,17 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.integration.redis.util.RedisLockRegistry;
 
+/**
+ * Builds the {@link RedisLockRegistry} bean backing distributed leader election.
+ */
 @Configuration
 public class RedisLockRegistryConfiguration {
+    /**
+     * @param redisConnectionFactory connection factory for the target Redis instance
+     * @param electorProperties      supplies the lock name (registry key is {@code
+     *                                <lockName>-lock-registry}) and the lease duration
+     * @return a {@link RedisLockRegistry} scoped to this application's lock
+     */
     @Bean
     @Nonnull
     public RedisLockRegistry redisLockRegistry(@Nonnull final RedisConnectionFactory redisConnectionFactory,

--- a/src/main/java/io/jaredbrown/k8s/leader/configuration/TaskSchedulerConfiguration.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/configuration/TaskSchedulerConfiguration.java
@@ -7,35 +7,48 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 
 import java.time.Clock;
 
+/**
+ * Beans supporting {@code ElectorService}'s scheduling: a single-threaded task scheduler and an
+ * injectable clock.
+ */
 @Configuration
 public class TaskSchedulerConfiguration {
+    /**
+     * @return a daemon {@link ThreadPoolTaskScheduler} pinned to a single thread.
+     * <p>{@code DistributedLock.unlock()} is thread-owned (see {@code
+     * ElectorService#awaitLockRelease}): a pool size above 1 would let lock acquisition
+     * ({@code lockLoop}) and renewal/release ({@code refreshLock}) run on different worker
+     * threads, throwing {@code IllegalStateException} off the acquiring thread. A single thread
+     * keeps every lock operation sequential and on the same thread by construction.
+     * <p>{@code setAcceptTasksAfterContextClose(true)} is required, not cosmetic:
+     * {@code ExecutorConfigurationSupport} listens for {@code ContextClosedEvent} and, by default,
+     * calls {@code executor.shutdown()} right there — published (and handled synchronously)
+     * BEFORE Spring invokes any {@code SmartLifecycle#stop()} (see
+     * {@code AbstractApplicationContext#doClose}: the {@code ContextClosedEvent} publish precedes
+     * {@code lifecycleProcessor.onClose()}). Since {@code ElectorService}'s own {@code stop()}
+     * submits the shutdown-time lock release to this same scheduler, without this flag that
+     * {@code submit()} call would always throw {@code TaskRejectedException} and the lock would
+     * leak every graceful shutdown — the exact bug this scheduler's thread-pinning exists to
+     * avoid. Setting this defers the executor's shutdown to its later
+     * {@code @PreDestroy}/{@code DisposableBean} callback, which runs after all
+     * {@code SmartLifecycle} beans have stopped.
+     */
     @Nonnull
     @Bean
     public ThreadPoolTaskScheduler taskScheduler() {
         final ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
-        // DistributedLock.unlock() is thread-owned (see ElectorService#awaitLockRelease): a pool
-        // size above 1 lets lock acquisition (lockLoop) and renewal/release (refreshLock) run on
-        // different worker threads, which throws IllegalStateException off the acquiring thread. A
-        // single thread keeps every lock operation sequential and on the same thread by construction.
         scheduler.setPoolSize(1);
         scheduler.setThreadNamePrefix("elector-");
         scheduler.setDaemon(true);
-        // ExecutorConfigurationSupport listens for ContextClosedEvent and, by default, calls
-        // executor.shutdown() right there - which is published (and handled synchronously) BEFORE
-        // Spring invokes any SmartLifecycle#stop() (see AbstractApplicationContext#doClose: the
-        // ContextClosedEvent publish precedes lifecycleProcessor.onClose()). Since ElectorService's
-        // own stop() submits the shutdown-time lock release to this same scheduler, without this
-        // flag that submit() would always throw TaskRejectedException and the lock would leak every
-        // graceful shutdown - the exact bug this scheduler exists to avoid. Setting this defers the
-        // executor's shutdown to its later @PreDestroy/DisposableBean callback, which runs after all
-        // SmartLifecycle beans have stopped.
         scheduler.setAcceptTasksAfterContextClose(true);
         scheduler.initialize();
         return scheduler;
     }
 
-    // System clock for time-based logic (e.g. the deadlock-grace window). Injected so tests can
-    // supply a controllable clock.
+    /**
+     * @return the system UTC clock, injected (rather than called directly) so tests can supply a
+     * controllable clock for time-based logic such as the deadlock-grace window
+     */
     @Nonnull
     @Bean
     public Clock clock() {

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorProperties.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorProperties.java
@@ -10,30 +10,40 @@ import org.springframework.validation.annotation.Validated;
 
 import java.time.Duration;
 
+/**
+ * Configuration properties for the leader-election sidecar (prefix {@code elector}).
+ */
 @Data
 @Validated
 @ConfigurationProperties(prefix = "elector")
 public class ElectorProperties {
+    /** Label key set to {@code true} on the leader Pod and {@code false} on every other pod. */
     @NotBlank(message = "elector.labelKey must be configured")
     private String labelKey;
 
+    /** Name of the distributed lock in Redis; the registry key is {@code <lockName>-lock-registry}. */
     @NotBlank(message = "elector.lockName must be configured")
     private String lockName;
 
+    /** Label key used to select the pods this elector labels and reconciles. */
     @NotBlank(message = "elector.selectorName must be configured")
     private String selectorLabelKey;
 
+    /** Label value paired with {@link #selectorLabelKey} to select the pods this elector reconciles. */
     @NotBlank(message = "elector.selectorValue must be configured")
     private String selectorLabelValue;
 
+    /** Lock TTL in Redis; the lock expires if not renewed within this window. */
     @NotNull
     @DurationMin(seconds = 1, message = "elector.leaseDuration must be at least 1s")
     private Duration leaseDuration = Duration.ofSeconds(120);
 
+    /** How often the leader renews the lock and reconciles leader labels. */
     @NotNull
     @DurationMin(seconds = 1, message = "elector.renewDeadline must be at least 1s")
     private Duration renewDeadline = Duration.ofSeconds(60);
 
+    /** How often a non-leader retries lock acquisition. */
     @NotNull
     @DurationMin(seconds = 1, message = "elector.retryPeriod must be at least 1s")
     private Duration retryPeriod = Duration.ofSeconds(5);
@@ -45,44 +55,56 @@ public class ElectorProperties {
     // it. This keeps application logic out of the elector and adds no tools to its image.
     // Disabled by default so existing consumers are unaffected.
 
-    // Gate leadership on the health probe. When false, the probe is never read and behavior is
-    // identical to a probe-less elector.
+    /**
+     * Gates leadership on the health probe. When {@code false}, the probe is never read and
+     * behavior is identical to a probe-less elector.
+     */
     private boolean healthProbeEnabled = false;
 
-    // Path to the status file the application maintains. Missing/unreadable file = unhealthy.
+    /** Path to the status file the application maintains. Missing/unreadable file = unhealthy. */
     private String healthProbeFilePath;
 
-    // The (trimmed) file content that means healthy. Anything else = unhealthy.
+    /** The (trimmed) file content that means healthy. Anything else = unhealthy. */
     private String healthProbeHealthyContent = "healthy";
 
-    // Reject the file if it has not been updated within this window, so a dead writer reads as
-    // unhealthy rather than stale-healthy. Set to zero to disable the freshness check.
+    /**
+     * Rejects the file if it has not been updated within this window, so a dead writer reads as
+     * unhealthy rather than stale-healthy. Set to zero to disable the freshness check.
+     */
     @NotNull
     private Duration healthProbeMaxAge = Duration.ofMinutes(2);
 
-    // Consecutive probe failures tolerated while already leader before relinquishing. Absorbs a
-    // transient blip or a normal gravity rebuild without flapping leadership. Must be >= 1 so a
-    // single probe failure cannot immediately demote the leader (0/negative would be nonsensical).
+    /**
+     * Consecutive probe failures tolerated while already leader before relinquishing. Absorbs a
+     * transient blip or a normal gravity rebuild without flapping leadership. Must be {@code >= 1}
+     * so a single probe failure cannot immediately demote the leader (0/negative would be
+     * nonsensical).
+     */
     @Min(value = 1, message = "elector.healthProbeFailureThreshold must be at least 1")
     private int healthProbeFailureThreshold = 3;
 
-    // If the lock is free but no pod is healthy, leadership would deadlock forever (e.g. a fresh
-    // install or an all-pods-wiped state). After the lock has been observed acquirable-but-this-
-    // pod-unhealthy for this long, acquire it anyway and lead in a degraded state. Zero is a valid,
-    // deliberate value (skip the grace window and break the deadlock immediately); only negative
-    // values - which would silently behave identically to zero - are rejected as almost certainly
-    // a typo.
+    /**
+     * If the lock is free but no pod is healthy, leadership would deadlock forever (e.g. a fresh
+     * install or an all-pods-wiped state). After the lock has been observed
+     * acquirable-but-this-pod-unhealthy for this long, acquire it anyway and lead in a degraded
+     * state. Zero is a valid, deliberate value (skip the grace window and break the deadlock
+     * immediately); only negative values - which would silently behave identically to zero - are
+     * rejected as almost certainly a typo.
+     */
     @NotNull
     @DurationMin(seconds = 0, message = "elector.healthProbeDeadlockGrace must not be negative")
     private Duration healthProbeDeadlockGrace = Duration.ofMinutes(5);
 
-    // How long an UNHEALTHY pod backs off before re-probing for leadership, instead of the tight
-    // retryPeriod a healthy pod uses. An unhealthy ex-leader that keeps re-acquiring the free lock
-    // every retryPeriod (to test eligibility) and releasing it starves the healthy peers that are
-    // trying to take over — a livelock that leaves the deployment leaderless. Backing off well past
-    // retryPeriod gives healthy peers uncontested acquisition windows so one of them leads promptly.
-    // Should comfortably exceed retryPeriod; well under healthProbeDeadlockGrace so the all-unhealthy
-    // escape hatch still fires on time (the unhealthy pod still re-probes ~grace/backoff times).
+    /**
+     * How long an unhealthy pod backs off before re-probing for leadership, instead of the tight
+     * {@link #retryPeriod} a healthy pod uses. An unhealthy ex-leader that keeps re-acquiring the
+     * free lock every {@code retryPeriod} (to test eligibility) and releasing it starves the
+     * healthy peers that are trying to take over — a livelock that leaves the deployment
+     * leaderless. Backing off well past {@code retryPeriod} gives healthy peers uncontested
+     * acquisition windows so one of them leads promptly. Should comfortably exceed
+     * {@code retryPeriod}; well under {@link #healthProbeDeadlockGrace} so the all-unhealthy
+     * escape hatch still fires on time (the unhealthy pod still re-probes ~grace/backoff times).
+     */
     @NotNull
     @DurationMin(seconds = 1, message = "elector.healthProbeUnhealthyBackoff must be at least 1s")
     private Duration healthProbeUnhealthyBackoff = Duration.ofSeconds(30);

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorService.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/ElectorService.java
@@ -20,6 +20,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+/**
+ * Drives distributed leader election over a Redis-backed {@link RedisLockRegistry}, keeping pod
+ * leader labels in sync via {@link LockCallbacks}.
+ *
+ * <p>Acquisition, renewal, and release all run on {@code taskScheduler}'s single thread (see that
+ * bean's Javadoc for why); optional health gating and a deadlock-grace escape hatch are described
+ * on {@link #lockLoop} and {@link #deadlockGraceExceeded}.
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -54,18 +62,22 @@ public class ElectorService implements SmartLifecycle {
     // Consecutive health-probe failures observed while already leading.
     private final AtomicInteger consecutiveProbeFailures = new AtomicInteger(0);
 
+    /**
+     * Labels self {@code leader=false} (so a freshly (re)created pod carries the label from boot
+     * rather than staying unlabeled until it wins or loses its first election), then schedules the
+     * first {@link #lockLoop} run.
+     */
     @Override
     public void start() {
         running.set(true);
         deadlockSince.set(null);
         consecutiveProbeFailures.set(0);
         log.info("Starting ElectorService");
-        // So a freshly (re)created pod carries the label from boot rather than staying unlabeled
-        // until it wins or loses its first election.
         callbacks.ensureSelfLabeled();
         taskScheduler.schedule(this::lockLoop, clock.instant());
     }
 
+    /** Cancels lock renewal and releases the lock (if held); see {@link #awaitLockRelease}. */
     @Override
     public void stop() {
         log.info("Stopping ElectorService");
@@ -79,12 +91,14 @@ public class ElectorService implements SmartLifecycle {
         return running.get();
     }
 
+    /** Delegates to {@link #stop()} so shutdown releases the lock even outside a normal Spring stop. */
     @PreDestroy
     public void onDestroy() {
         log.info("@PreDestroy: releasing lock if held");
         stop();
     }
 
+    /** Cancels the scheduled renewal task, if one is running. */
     private void cancelRefreshTask() {
         final ScheduledFuture<?> future = refreshFuture.getAndSet(null);
         if (future != null && !future.isCancelled()) {
@@ -92,12 +106,17 @@ public class ElectorService implements SmartLifecycle {
         }
     }
 
-    // DistributedLock.unlock() is thread-owned (RedisLockRegistry.RedisLock wraps a local
-    // ReentrantLock and throws IllegalStateException if unlocked off-thread). Acquisition always
-    // happens on the taskScheduler thread (lockLoop/refreshLock), but SmartLifecycle#stop() runs on
-    // whatever thread Spring's context shutdown uses, so releasing directly here would always fail
-    // and leak the Redis key for the full lease TTL. Route the release through the scheduler thread
-    // instead and wait briefly for it to finish.
+    /**
+     * Routes the shutdown-time lock release onto the scheduler thread and waits up to
+     * {@link #RELEASE_TIMEOUT} for it to finish.
+     *
+     * <p>{@code DistributedLock.unlock()} is thread-owned ({@code RedisLockRegistry.RedisLock}
+     * wraps a local {@code ReentrantLock} and throws {@code IllegalStateException} if unlocked
+     * off-thread). Acquisition always happens on the {@code taskScheduler} thread ({@code
+     * lockLoop}/{@code refreshLock}), but {@code SmartLifecycle#stop()} runs on whatever thread
+     * Spring's context shutdown uses, so releasing directly here would always fail and leak the
+     * Redis key for the full lease TTL.
+     */
     private void awaitLockRelease() {
         try {
             taskScheduler
@@ -113,8 +132,10 @@ public class ElectorService implements SmartLifecycle {
         }
     }
 
-    // Runs on the scheduler thread (see awaitLockRelease). Only a pod that was actually leading
-    // needs its label cleared here - a non-leader pod's label is already false.
+    /**
+     * Runs on the scheduler thread (see {@link #awaitLockRelease}). Only a pod that was actually
+     * leading needs its label cleared here - a non-leader pod's label is already false.
+     */
     private void releaseLockAndClearLabelIfHeld() {
         if (releaseLockIfHeld()) {
             callbacks.onShutdown();
@@ -123,8 +144,10 @@ public class ElectorService implements SmartLifecycle {
 
     // --- Refresh logic: interval is configurable via electorProperties.getRenewDeadline() ---
 
-    // Returns whether this pod was holding the lock (i.e. was leader), regardless of whether the
-    // unlock call itself succeeded.
+    /**
+     * @return whether this pod was holding the lock (i.e. was leader), regardless of whether the
+     * unlock call itself succeeded
+     */
     private boolean releaseLockIfHeld() {
         final DistributedLock currentLock = lock.getAndSet(null);
         if (currentLock != null) {
@@ -139,6 +162,13 @@ public class ElectorService implements SmartLifecycle {
         return false;
     }
 
+    /**
+     * Attempts lock acquisition, gated by the health probe: an unhealthy pod that still acquires
+     * the (free) lock releases it again and backs off (see {@link #scheduleUnhealthyRetry}), unless
+     * {@link #deadlockGraceExceeded} says every candidate has been unhealthy long enough to lead in
+     * a degraded state anyway. Reschedules itself via {@link #scheduleRetry} or {@link
+     * #scheduleUnhealthyRetry} on every path that doesn't lead to {@link #becomeLeader}.
+     */
     private void lockLoop() {
         if (!running.get()) {
             return;
@@ -220,6 +250,10 @@ public class ElectorService implements SmartLifecycle {
         }
     }
 
+    /**
+     * Takes ownership of {@code newLock}, reconciles leader labels, and schedules renewal. Releases
+     * the lock and retries instead if the post-acquire callback fails.
+     */
     private void becomeLeader(final DistributedLock newLock) {
         // Acquiring leadership ends any current free-lock standoff, so the deadlock-grace window
         // must start fresh next time. Resetting here (rather than only on the healthy path) stops a
@@ -241,8 +275,11 @@ public class ElectorService implements SmartLifecycle {
         scheduleRefreshTask();
     }
 
-    // True once the lock has been observed free-but-this-pod-unhealthy for at least the configured
-    // grace. Starts the timer on first such observation (returning false then).
+    /**
+     * @return {@code true} once the lock has been observed free-but-this-pod-unhealthy for at
+     * least the configured grace. Starts the timer on first such observation (returning
+     * {@code false} then).
+     */
     private boolean deadlockGraceExceeded() {
         final Instant now = clock.instant();
         final Instant witness = deadlockSince.compareAndExchange(null, now);
@@ -252,6 +289,7 @@ public class ElectorService implements SmartLifecycle {
                        .compareTo(electorProperties.getHealthProbeDeadlockGrace()) >= 0;
     }
 
+    /** Reschedules {@link #lockLoop} after {@code retryPeriod}, if still running. */
     private void scheduleRetry() {
         if (running.get()) {
             taskScheduler.schedule(this::lockLoop,
@@ -261,8 +299,11 @@ public class ElectorService implements SmartLifecycle {
         }
     }
 
-    // Re-probe schedule for an UNHEALTHY pod: a longer backoff than retryPeriod so it stops
-    // contending for the lock every few seconds and lets healthy peers take over (see lockLoop).
+    /**
+     * Re-probe schedule for an unhealthy pod: a longer backoff than {@code retryPeriod} so it stops
+     * contending for the lock every few seconds and lets healthy peers take over (see
+     * {@link #lockLoop}).
+     */
     private void scheduleUnhealthyRetry() {
         if (running.get()) {
             taskScheduler.schedule(this::lockLoop,
@@ -274,6 +315,7 @@ public class ElectorService implements SmartLifecycle {
 
     // --- Lock lost handling & reacquire ---
 
+    /** Cancels any existing renewal task and schedules {@link #refreshLock} at {@code renewDeadline}. */
     private void scheduleRefreshTask() {
         cancelRefreshTask();
         final ScheduledFuture<?> future = taskScheduler.scheduleAtFixedRate(this::refreshLock,
@@ -284,6 +326,11 @@ public class ElectorService implements SmartLifecycle {
         refreshFuture.set(future);
     }
 
+    /**
+     * Runs on every renewal tick: relinquishes leadership if the health probe has failed
+     * {@code healthProbeFailureThreshold} consecutive times, otherwise renews the lock (with one
+     * immediate retry; see {@link #renewLockWithRetry}) and reconciles leader labels.
+     */
     private void refreshLock() {
         if (!running.get()) {
             handleLockLost();
@@ -325,9 +372,12 @@ public class ElectorService implements SmartLifecycle {
         }
     }
 
-    // A single transient Redis blip should not cost leadership outright: renewDeadline (60s
-    // default) leaves ample slack before the lease (120s default) actually expires, so one
-    // immediate retry absorbs a blip that would otherwise trigger a full re-election.
+    /**
+     * Renews the lock, retrying once immediately on failure before propagating. A single transient
+     * Redis blip should not cost leadership outright: {@code renewDeadline} (60s default) leaves
+     * ample slack before the lease (120s default) actually expires, so one immediate retry absorbs
+     * a blip that would otherwise trigger a full re-election.
+     */
     private void renewLockWithRetry() {
         try {
             renewLockOnce();
@@ -339,6 +389,7 @@ public class ElectorService implements SmartLifecycle {
         }
     }
 
+    /** Extends the lock's Redis TTL by {@code leaseDuration}; throws on failure. */
     private void renewLockOnce() {
         lockRegistry.renewLock(electorProperties.getLockName(), electorProperties.getLeaseDuration());
         log.debug("Lock TTL extended by {} seconds",
@@ -347,20 +398,26 @@ public class ElectorService implements SmartLifecycle {
                           .get(ChronoUnit.SECONDS));
     }
 
-    // Re-confirms this pod still holds the Redis lock, and refreshes its lease as a side effect.
-    // Passed into LockCallbacks#reconcileLeaderLabels so a long-running label reconcile stops the
-    // moment ownership is lost instead of stamping stale labels. renewLock's Lua script only extends
-    // the key while Redis still maps it to THIS registry's client id, so a thrown/false result is a
-    // genuine "no longer the owner" signal (a lapsed lease another pod already took), not just local
-    // state — a purely local check can't see a Redis-side takeover. Runs on the scheduler thread, the
-    // same thread as the reconcile that calls it.
-    //
-    // Also gates on running: renewLock alone would keep succeeding straight through shutdown, letting
-    // a reconcile spanning many pod-list pages stall the single scheduler thread well past stop()'s 5s
-    // RELEASE_TIMEOUT. This matters most for the acquisition-time reconcile (becomeLeader ->
-    // onLockAcquired), which runs before scheduleRefreshTask() creates refreshFuture — cancelRefreshTask()
-    // has nothing to interrupt yet at that point, so this running check is the only thing that can cut a
-    // long reconcile short once stop() has fired, letting the queued lock-release task run promptly.
+    /**
+     * Re-confirms this pod still holds the Redis lock, and refreshes its lease as a side effect.
+     * Passed into {@code LockCallbacks#reconcileLeaderLabels} so a long-running label reconcile
+     * stops the moment ownership is lost instead of stamping stale labels. {@code renewLock}'s Lua
+     * script only extends the key while Redis still maps it to THIS registry's client id, so a
+     * thrown/false result is a genuine "no longer the owner" signal (a lapsed lease another pod
+     * already took), not just local state — a purely local check can't see a Redis-side takeover.
+     * Runs on the scheduler thread, the same thread as the reconcile that calls it.
+     *
+     * <p>Also gates on {@code running}: {@code renewLock} alone would keep succeeding straight
+     * through shutdown, letting a reconcile spanning many pod-list pages stall the single scheduler
+     * thread well past {@code stop()}'s 5s {@link #RELEASE_TIMEOUT}. This matters most for the
+     * acquisition-time reconcile ({@code becomeLeader -> onLockAcquired}), which runs before
+     * {@link #scheduleRefreshTask()} creates {@code refreshFuture} — {@link #cancelRefreshTask()}
+     * has nothing to interrupt yet at that point, so this running check is the only thing that can
+     * cut a long reconcile short once {@code stop()} has fired, letting the queued lock-release
+     * task run promptly.
+     *
+     * @return whether this pod's ownership of the lock was confirmed
+     */
     boolean stillOwnsLock() {
         if (!running.get() || lock.get() == null) {
             return false;
@@ -376,6 +433,7 @@ public class ElectorService implements SmartLifecycle {
         }
     }
 
+    /** Cancels renewal, releases the lock, notifies {@link LockCallbacks#onLockLost()}, and re-enters acquisition if still running. */
     private void handleLockLost() {
         cancelRefreshTask();
         releaseLockIfHeld();
@@ -389,6 +447,7 @@ public class ElectorService implements SmartLifecycle {
         }
     }
 
+    /** @return {@link Integer#MIN_VALUE} so this service starts as early as possible. */
     @Override
     public int getPhase() {
         return Integer.MIN_VALUE;

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/HealthProbe.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/HealthProbe.java
@@ -58,6 +58,10 @@ public class HealthProbe {
 
     private volatile ExecutorService fileReadExecutor = newFileReadExecutor();
 
+    /**
+     * @return a fresh single-thread daemon executor dedicated to the bounded file read described
+     * in this class's read-timeout note
+     */
     private static ExecutorService newFileReadExecutor() {
         return Executors.newSingleThreadExecutor(runnable -> {
             final Thread thread = new Thread(runnable, "health-probe-file-read");
@@ -66,6 +70,7 @@ public class HealthProbe {
         });
     }
 
+    /** Stops the background read executor on application shutdown. */
     @PreDestroy
     void shutdown() {
         fileReadExecutor.shutdownNow();

--- a/src/main/java/io/jaredbrown/k8s/leader/elector/LockCallbacks.java
+++ b/src/main/java/io/jaredbrown/k8s/leader/elector/LockCallbacks.java
@@ -19,6 +19,10 @@ import org.springframework.util.StringUtils;
 import java.util.Map;
 import java.util.function.BooleanSupplier;
 
+/**
+ * Callbacks invoked by {@code ElectorService} to keep pod leader labels in sync with the current
+ * election result.
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
@@ -42,10 +46,14 @@ public class LockCallbacks {
     @Value("${POD_NAME}")
     private String selfPodName;
 
-    // @Value above only rejects a totally absent property; POD_NAME="" resolves successfully and
-    // would silently reproduce the same bug removing the "unknown" default was meant to fix - every
-    // pod.getMetadata().getName().equals(selfPodName) comparison below would fail, so this pod would
-    // never match "isLeader" even while holding the Redis lock. Fail startup on blank too.
+    /**
+     * Fails startup if {@code POD_NAME} is blank.
+     *
+     * <p>{@code @Value} above only rejects a totally absent property; {@code POD_NAME=""} resolves
+     * successfully and would silently reproduce the same bug removing the "unknown" default was
+     * meant to fix - every {@code pod.getMetadata().getName().equals(selfPodName)} comparison below
+     * would fail, so this pod would never match "isLeader" even while holding the Redis lock.
+     */
     @PostConstruct
     void validateSelfPodName() {
         if (!StringUtils.hasText(selfPodName)) {
@@ -53,37 +61,49 @@ public class LockCallbacks {
         }
     }
 
+    /**
+     * Reconciles leader labels after acquiring the lock.
+     *
+     * @param stillLeader re-confirms leadership mid-reconcile; see {@link #reconcileLeaderLabels}
+     */
     public void onLockAcquired(final BooleanSupplier stillLeader) {
         log.info("Lock acquired - reconciling leader labels across deployment");
         reconcileLeaderLabels(stillLeader);
     }
 
-    // Brings every pod's leader label in line with the current election result: true on self,
-    // false on everyone else. Idempotent (skips pods whose label already matches) and safe to call
-    // repeatedly, so ElectorService also calls this on every successful lock renewal — that self-
-    // heals a label a prior attempt failed to set (a slow API server, a pod created after the last
-    // election) instead of leaving it wrong until the next leadership change. Never throws: a
-    // labeling problem is a side effect of leadership, not a reason to give it up, and the next
-    // renewal tick (at most renewDeadline away) retries automatically.
-    //
-    // Paginated (RECONCILE_LIST_PAGE_SIZE per page, matching client-go's own default chunk size) and
-    // patches each page's drifted pods before fetching the next, rather than buffering the whole
-    // match set first. Both are attacker-inflated-pod-count defenses: an unpaginated list() could
-    // exceed K8sClientConfiguration's 2s request timeout outright, and buffering every page before
-    // patching would leave heap usage unbounded even though each individual request stays small.
-    // Processing page-by-page bounds peak memory to one page's worth of pods regardless of total
-    // match count.
-    //
-    // stillLeader re-confirms leadership (Redis-side; see ElectorService#stillOwnsLock) immediately
-    // before mutating each drifted pod, and again before fetching another page. A reconcile that
-    // outlives the lease — a very slow API server, many drifted pods, or simply many pages — must not
-    // keep stamping this pod's stale identity (or keep paginating at all) after another pod has taken
-    // over the lock: stamping stale labels would flip the new leader's label back to false and leave
-    // the deployment momentarily leaderless, and unconditionally continued pagination could stall the
-    // single scheduler thread past renewDeadline. Every stillLeader call besides the last also renews
-    // the Redis lease as a side effect, so a long-but-still-legitimate multi-page reconcile keeps the
-    // lease alive instead of racing it. The pre-next-page check only fires when another page remains,
-    // so the common single-page case issues no extra Redis call beyond what patching already needs.
+    /**
+     * Brings every pod's leader label in line with the current election result: true on self,
+     * false on everyone else. Idempotent (skips pods whose label already matches) and safe to call
+     * repeatedly, so {@code ElectorService} also calls this on every successful lock renewal — that
+     * self-heals a label a prior attempt failed to set (a slow API server, a pod created after the
+     * last election) instead of leaving it wrong until the next leadership change. Never throws: a
+     * labeling problem is a side effect of leadership, not a reason to give it up, and the next
+     * renewal tick (at most {@code renewDeadline} away) retries automatically.
+     *
+     * <p>Paginated ({@link #RECONCILE_LIST_PAGE_SIZE} per page, matching client-go's own default
+     * chunk size) and patches each page's drifted pods before fetching the next, rather than
+     * buffering the whole match set first. Both are attacker-inflated-pod-count defenses: an
+     * unpaginated {@code list()} could exceed {@code K8sClientConfiguration}'s 2s request timeout
+     * outright, and buffering every page before patching would leave heap usage unbounded even
+     * though each individual request stays small. Processing page-by-page bounds peak memory to
+     * one page's worth of pods regardless of total match count.
+     *
+     * @param stillLeader re-confirms leadership (Redis-side; see {@code
+     *                     ElectorService#stillOwnsLock}) immediately before mutating each drifted
+     *                     pod, and again before fetching another page. A reconcile that outlives
+     *                     the lease — a very slow API server, many drifted pods, or simply many
+     *                     pages — must not keep stamping this pod's stale identity (or keep
+     *                     paginating at all) after another pod has taken over the lock: stamping
+     *                     stale labels would flip the new leader's label back to false and leave
+     *                     the deployment momentarily leaderless, and unconditionally continued
+     *                     pagination could stall the single scheduler thread past
+     *                     {@code renewDeadline}. Every {@code stillLeader} call besides the last
+     *                     also renews the Redis lease as a side effect, so a long-but-still-
+     *                     legitimate multi-page reconcile keeps the lease alive instead of racing
+     *                     it. The pre-next-page check only fires when another page remains, so the
+     *                     common single-page case issues no extra Redis call beyond what patching
+     *                     already needs.
+     */
     public void reconcileLeaderLabels(final BooleanSupplier stillLeader) {
         final String namespace = kubernetesClient.getNamespace();
         try {
@@ -147,6 +167,10 @@ public class LockCallbacks {
         }
     }
 
+    /**
+     * @return whether {@code pod}'s current leader label differs from what {@code isLeader}
+     * implies (including when the pod carries no labels map at all)
+     */
     private boolean needsLabelUpdate(final Pod pod, final boolean isLeader) {
         final Map<String, String> labels = pod
                 .getMetadata()
@@ -157,6 +181,7 @@ public class LockCallbacks {
                 .equals(current);
     }
 
+    /** Patches {@code podName}'s leader label; propagates any {@link KubernetesClientException}. */
     private void patchPodLeaderLabel(final String namespace, final String podName, final boolean isLeader) {
         final Pod patch = new PodBuilder()
                 .withNewMetadata()
@@ -172,6 +197,10 @@ public class LockCallbacks {
         log.debug("Set {}={} on pod {}", electorProperties.getLabelKey(), isLeader, podName);
     }
 
+    /**
+     * @return {@code true} if the patch succeeded; on failure, logs (at error for the leader, warn
+     * otherwise) and returns {@code false} rather than throwing
+     */
     private boolean updatePodLeaderLabel(final String namespace, final String podName, final boolean isLeader) {
         try {
             patchPodLeaderLabel(namespace, podName, isLeader);
@@ -188,23 +217,28 @@ public class LockCallbacks {
         }
     }
 
-    // Called once on startup so a freshly (re)created pod always carries the label from boot
-    // instead of staying unlabeled until it wins (or loses) its first election.
+    /**
+     * Called once on startup so a freshly (re)created pod always carries the label from boot
+     * instead of staying unlabeled until it wins (or loses) its first election.
+     */
     public void ensureSelfLabeled() {
         log.info("Initializing leader label on self at startup");
         updatePodLeaderLabel(kubernetesClient.getNamespace(), selfPodName, false);
     }
 
+    /** Removes the leader label from self after losing the lock. */
     public void onLockLost() {
         log.warn("Lock lost - removing leader label from self");
         updatePodLeaderLabel(kubernetesClient.getNamespace(), selfPodName, false);
     }
 
-    // Called on graceful shutdown, but only for a pod that was actually leading (see
-    // ElectorService#releaseLockAndClearLabelIfHeld) — otherwise the label is already false. Without
-    // this, a departing leader would stay labeled true for the rest of its terminationGracePeriod,
-    // which anything selecting directly on the label (not just the Service, which drops NotReady
-    // endpoints immediately) could still match.
+    /**
+     * Called on graceful shutdown, but only for a pod that was actually leading (see {@code
+     * ElectorService#releaseLockAndClearLabelIfHeld}) — otherwise the label is already false.
+     * Without this, a departing leader would stay labeled true for the rest of its
+     * {@code terminationGracePeriod}, which anything selecting directly on the label (not just the
+     * Service, which drops NotReady endpoints immediately) could still match.
+     */
     public void onShutdown() {
         log.info("Shutting down while leading - removing leader label from self");
         updatePodLeaderLabel(kubernetesClient.getNamespace(), selfPodName, false);


### PR DESCRIPTION
## Summary
- Follow-up to a comment audit: only `HealthProbe.java` carried Javadoc, everything else relied on plain `//` comments for the same why-content.
- Converts those comments into Javadoc across `Application`, both configuration beans (`K8sClientConfiguration`, `RedisLockRegistryConfiguration`, `TaskSchedulerConfiguration`), `ElectorProperties`, `ElectorService`, and `LockCallbacks`.
- Covers public AND private methods (per request), plus class-level Javadoc for every class. No behavior changes — comments only.

## Test plan
- [x] `mvn clean compile` — clean build
- [x] `mvn test` (excluding the Testcontainers IT) — 86/86 pass

https://claude.ai/code/session_013vAsTCe7xYicFS7BY72GAc