### PR TITLE
chore(renovate): use the local> preset reference, drop a redundant extend

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>jabrown93/.github//renovate-config.json",
-    "customManagers:mavenPropertyVersions"
+    "local>jabrown93/.github:renovate-config"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Part of a Renovate audit across all 17 owned repos. Independent — merge in any order.

## Preset reference

Ten repos already write `local>jabrown93/.github:renovate-config`; seven, including this one, write `github>jabrown93/.github//renovate-config.json`. Both resolve to the same file, so this is purely a consistency change. `local>` also uses the configured platform rather than hardcoding GitHub.

## Redundant extend

`customManagers:mavenPropertyVersions` is already extended by the shared preset (`renovate-config.json` line 20). Resolving it a second time here adds nothing.

**No behavior change.** The maven `!/.*-legacy$/` exclusion rule is untouched, and `mavenPropertyVersions` still applies — via the preset.

`renovate-config-validator` passes.

---
🤖 Authored by Claude (AI agent) at the repo owner's direction.

https://claude.ai/code/session_012gJxRyCGZLCG81R3jNvWes